### PR TITLE
Fix merging of loadOnStartup annotation values with web.xml metadata

### DIFF
--- a/web/src/main/java/org/jboss/metadata/merge/web/spec/ServletMetaDataMerger.java
+++ b/web/src/main/java/org/jboss/metadata/merge/web/spec/ServletMetaDataMerger.java
@@ -142,7 +142,7 @@ public class ServletMetaDataMerger {
         // Load on startup
         if (!dest.getLoadOnStartupSet()) {
             if (webFragmentMetaData.getLoadOnStartupSet()) {
-                dest.setLoadOnStartup(webFragmentMetaData.getLoadOnStartup());
+                dest.setLoadOnStartupInt(webFragmentMetaData.getLoadOnStartupInt());
             }
         } else {
             if (!resolveConflicts && webFragmentMetaData.getLoadOnStartupSet()

--- a/web/src/main/java/org/jboss/metadata/web/spec/ServletMetaData.java
+++ b/web/src/main/java/org/jboss/metadata/web/spec/ServletMetaData.java
@@ -105,11 +105,13 @@ public class ServletMetaData extends NamedMetaDataWithDescriptionGroup {
     }
 
     public void setLoadOnStartup(String loadOnStartup) {
-        this.loadOnStartup = loadOnStartup;
-        try {
-            setLoadOnStartupInt(Integer.parseInt(loadOnStartup));
-        } catch (NumberFormatException e) {
-            setLoadOnStartupInt(0);
+        if (loadOnStartup != null) {
+            this.loadOnStartup = loadOnStartup;
+            try {
+                setLoadOnStartupInt(Integer.parseInt(loadOnStartup));
+            } catch (NumberFormatException e) {
+                setLoadOnStartupInt(0);
+            }
         }
     }
     public int getLoadOnStartupDefault() {


### PR DESCRIPTION
This is a fix for JBMETA-346
The first problem this request solves is, that ServletMetaData.setLoadOnStartup(String) sets the value to 0 when the given string is null. This happens, when a servlet element in the web.xml does not contain a load-on-startup element.
The second problem solved is, that the ServletMetaData instance only contains the int value but not the string value for the meta data collected from the annotations. E.g. getLoadOnStartup() is null but getLoadOnStartupInt() already contains the correct value()
