### PR TITLE
Fix tests on windows

### DIFF
--- a/ejb/src/test/java/org/jboss/metadata/ejb/test/common/ValidationHelper.java
+++ b/ejb/src/test/java/org/jboss/metadata/ejb/test/common/ValidationHelper.java
@@ -65,8 +65,8 @@ public class ValidationHelper {
        system.put("http://www.jboss.org/j2ee/schema/trans-timeout-1_0.xsd", "/schema/trans-timeout-1_0.xsd");
        // Somehow this gives a broken URI, see http://en.wikipedia.org/wiki/File_URI_scheme
 //      system.put(new URL(new File(".").toURI().toURL(), "cache-test.xsd").toString(), "cache-test.xsd");
-       system.put("file://" + new File(System.getProperty("user.dir"), "cache-test.xsd").toURI().getRawPath(), "cache-test.xsd");
-       system.put("file://" + new File(System.getProperty("user.dir"), "tx-test.xsd").toURI().getRawPath(), "tx-test.xsd");
+       system.put("file://" + new File(System.getProperty("user.dir"), "cache-test.xsd").toURI().toASCIIString().substring(5), "cache-test.xsd");
+       system.put("file://" + new File(System.getProperty("user.dir"), "tx-test.xsd").toURI().toASCIIString().substring(5), "tx-test.xsd");
        parser.setEntityResolver(new EntityResolver()
        {
           @Override


### PR DESCRIPTION
Attempt to build 'metadata' on Windows platform fails while running 'org.jboss.metadata.ejb.test.extension.ExtensionTestCase'. The root cause of the problem is using of System.getProperty("user.dir") statement to construct part of URL for test schema file - on Windows this results in incorrect URL due to different path separators. Another problem occurs if non-ASCII characters are present in the patch - they need to be properly encoded.
