### PR TITLE
Modify two test cases in metadata/ejb and metadata/web.

### DIFF
--- a/ejb/src/test/java/org/jboss/metadata/ejb/test/parser/jboss/ejb3/AbstractEJBBoundMetaDataParserUnitTestCase.java
+++ b/ejb/src/test/java/org/jboss/metadata/ejb/test/parser/jboss/ejb3/AbstractEJBBoundMetaDataParserUnitTestCase.java
@@ -50,7 +50,7 @@ public class AbstractEJBBoundMetaDataParserUnitTestCase extends AbstractEJBEvery
         Map<String, AbstractMetaDataParser<?>> parsers = new HashMap<String, AbstractMetaDataParser<?>>();
         parsers.put("urn:iiop", parser);
         try {
-            UnmarshallingHelper.unmarshalJboss(EjbJarMetaData.class, "../test/parser/jboss/ejb3/invalid-jboss-ejb3.xml",
+            UnmarshallingHelper.unmarshalJboss(EjbJarMetaData.class, "/org/jboss/metadata/ejb/test/parser/jboss/ejb3/invalid-jboss-ejb3.xml",
                     parsers);
             fail("The unmarshalling of the XML did not throw the expected expection");
         } catch (XMLStreamException e) {
@@ -63,7 +63,7 @@ public class AbstractEJBBoundMetaDataParserUnitTestCase extends AbstractEJBEvery
         Map<String, AbstractMetaDataParser<?>> parsers = new HashMap<String, AbstractMetaDataParser<?>>();
         parsers.put("urn:iiop", parser);
         try {
-            UnmarshallingHelper.unmarshalJboss(EjbJarMetaData.class, "../test/parser/jboss/ejb3/valid-jboss-ejb3.xml", parsers);
+            UnmarshallingHelper.unmarshalJboss(EjbJarMetaData.class, "/org/jboss/metadata/ejb/test/parser/jboss/ejb3/valid-jboss-ejb3.xml", parsers);
         } catch (Throwable e) {
             e.printStackTrace();
             fail("The unmarshalling of the XML thrown an unexpected exception");

--- a/web/src/test/java/org/jboss/test/metadata/web/WebApp24ValidationUnitTestCase.java
+++ b/web/src/test/java/org/jboss/test/metadata/web/WebApp24ValidationUnitTestCase.java
@@ -47,17 +47,14 @@ public class WebApp24ValidationUnitTestCase extends WebAppUnitTestCase {
 
     private static Schema jaxpSchema;
 
-    public void testJAXPSchema() throws Exception {
+    public void testJAXPValidation() throws Exception {
         URL schemaURL = new URL("http://java.sun.com/xml/ns/j2ee/web-app_2_4.xsd");
         XMLResourceResolver resolver = new XMLResourceResolver();
         InputSource source = resolver.resolveEntity(schemaURL.toExternalForm(), null);
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
         factory.setResourceResolver(resolver);
         jaxpSchema = factory.newSchema(new StreamSource(source.getByteStream(), schemaURL.toExternalForm()));
-    }
-
-    public void testJAXPValidation() throws Exception {
-
+        
         DocumentBuilderFactory domBuilderFactory = DocumentBuilderFactory.newInstance();
         domBuilderFactory.setNamespaceAware(true);
         DocumentBuilder builder = domBuilderFactory.newDocumentBuilder();


### PR DESCRIPTION
Make AbstractEJBBoundMetaDataParserUnitTestCase run successfully with JDK 6.
Merge two test methods in WebApp24ValidationUnitTestCase as one to resolve test order dependency.
