### PR TITLE
[WFLY-800] Fix wrong handling of ignored elements on EAR parsing

### DIFF
--- a/common/src/main/java/org/jboss/metadata/parser/util/MetaDataElementParser.java
+++ b/common/src/main/java/org/jboss/metadata/parser/util/MetaDataElementParser.java
@@ -389,6 +389,27 @@ public class MetaDataElementParser implements XMLStreamConstants {
         }
     }
 
+    /**
+     * Consume the element content of an XML stream reader (e.g. in the event of a non-fatal parse error).
+     *
+     * @param reader the XML stream reader
+     */
+    protected static void consumeElementContent(final XMLStreamReader reader) throws XMLStreamException {
+        while (reader.hasNext()) {
+            switch (reader.next()) {
+                case END_ELEMENT: {
+                    return;
+                }
+                case START_ELEMENT: {
+                    consumeElementContent(reader);
+                    break;
+                }
+                default: {
+                    // ignore
+                }
+            }
+        }
+    }
 
     private static final Comparator<Object> NATURAL = new Comparator<Object>() {
         @SuppressWarnings("unchecked")

--- a/ear/src/main/java/org/jboss/metadata/parser/jboss/JBossAppMetaDataParser.java
+++ b/ear/src/main/java/org/jboss/metadata/parser/jboss/JBossAppMetaDataParser.java
@@ -128,7 +128,7 @@ public class JBossAppMetaDataParser extends EarMetaDataParser {
                     }
                     case MODULE_ORDER: {
                         logger.warn("module-order element in jboss-app.xml is deprecated and has been ignored");
-                        //depricated
+                        consumeElementContent(reader);
                         break;
                     }
                     case SECURITY_DOMAIN: {
@@ -141,6 +141,7 @@ public class JBossAppMetaDataParser extends EarMetaDataParser {
                     }
                     case JMX_NAME: {
                         logger.warn("jmx-name element in jboss-app.xml is deprecated and has been ignored");
+                        consumeElementContent(reader);
                         break;
                     }
                     case LIBRARY_DIRECTORY: {
@@ -148,8 +149,8 @@ public class JBossAppMetaDataParser extends EarMetaDataParser {
                         break;
                     }
                     case LOADER_REPOSITORY: {
-                        parseLoaderRepository(reader, propertyReplacer);
                         logger.warn("loader-repository element in jboss-app.xml is deprecated and has been ignored");
+                        parseLoaderRepository(reader, propertyReplacer);
                         break;
                     }
                     case MODULE: {


### PR DESCRIPTION
Instead of leaving the parser in an invalid state, consume the element content.  Add consume method for use by other parsers as well.
