### PR TITLE
JBMETA-368 timer-method can not be set in ejb-jar.xml for SingletonBeans

### DIFF
--- a/ejb/src/main/java/org/jboss/metadata/ejb/spec/AbstractGenericBeanMetaData.java
+++ b/ejb/src/main/java/org/jboss/metadata/ejb/spec/AbstractGenericBeanMetaData.java
@@ -669,8 +669,9 @@ public abstract class AbstractGenericBeanMetaData extends AbstractCommonMessageD
      * @throws IllegalArgumentException for a null timeoutMethod
      */
     public void setTimeoutMethod(NamedMethodMetaData timeoutMethod) {
-        if (getEjbType() != EjbType.MESSAGE_DRIVEN && getSessionType() != null && getSessionType() != SessionType.Stateless)
-            throw new IllegalStateException("EJB 3.1 FR 4.3.8: Only stateless beans can have timeouts: " + this);
+        if (getEjbType() != EjbType.MESSAGE_DRIVEN && getSessionType() != null
+                && getSessionType() != SessionType.Stateless && getSessionType() != SessionType.Singleton )
+            throw new IllegalStateException("EJB 3.1 FR 4.3.8: Only stateless or singleton beans can have timeouts: " + this);
         super.setTimeoutMethod(timeoutMethod);
     }
 

--- a/ejb/src/test/java/org/jboss/test/metadata/ejb/AbstractEJBEverythingTest.java
+++ b/ejb/src/test/java/org/jboss/test/metadata/ejb/AbstractEJBEverythingTest.java
@@ -100,7 +100,7 @@ public abstract class AbstractEJBEverythingTest extends AbstractJavaEEEverything
         IEnterpriseBeansMetaData enterpriseBeansMetaData = ejbJarMetaData.getEnterpriseBeans();
         assertNotNull(enterpriseBeansMetaData);
         assertId(mode == Mode.SPEC ? "enterprise-beans" : "jboss-enterprise-beans", enterpriseBeansMetaData);
-        assertEquals(15, enterpriseBeansMetaData.size());
+        assertEquals(16, enterpriseBeansMetaData.size());
 
         final String sessionPrefix = mode == Mode.SPEC ? "session" : "jbossSession";
         assertNullSession(sessionPrefix + "0", enterpriseBeansMetaData, mode);

--- a/ejb/src/test/resources/org/jboss/metadata/ejb/test/merge/EjbJar31Everything_testEverything.xml
+++ b/ejb/src/test/resources/org/jboss/metadata/ejb/test/merge/EjbJar31Everything_testEverything.xml
@@ -537,6 +537,18 @@
 
       </session>
 
+      <session id="sessionSingleton-id">
+         <ejb-name>sessionSEjbName</ejb-name>
+         <ejb-class>sessionSEjbClass</ejb-class>
+         <session-type>Singleton</session-type>
+         <timeout-method id="sessionSingletonTimeoutMethod-id">
+            <method-name>sessionSingletonTimeoutMethod</method-name>
+            <method-params>
+               <method-param>sessionSingletonTimeoutMethodParam1</method-param>
+            </method-params>
+         </timeout-method>
+      </session>
+
       <session id="session2-id">
       
          <description>en-session2-desc</description>

--- a/ejb/src/test/resources/org/jboss/test/metadata/ejb/EjbJar3xEverything_testEverything.xml
+++ b/ejb/src/test/resources/org/jboss/test/metadata/ejb/EjbJar3xEverything_testEverything.xml
@@ -792,6 +792,18 @@
          </security-identity>
 
       </session>
+      
+      <session id="sessionSingleton-id">
+         <ejb-name>sessionSEjbName</ejb-name>
+         <ejb-class>sessionSEjbClass</ejb-class>
+         <session-type>Singleton</session-type>
+         <timeout-method id="sessionSingletonTimeoutMethod-id">
+            <method-name>sessionSingletonTimeoutMethod</method-name>
+            <method-params>
+               <method-param>sessionSingletonTimeoutMethodParam1</method-param>
+            </method-params>
+         </timeout-method>
+      </session>
 
       <session id="session2-id">
       


### PR DESCRIPTION
Fix for https://issues.jboss.org/browse/JBMETA-368
add a Singleton for the metadata test with a timeout-method
