### PR TITLE
[WFLY-3699] Missing param-name in a web.xml causes NullPointerException ...

### DIFF
--- a/common/src/main/java/org/jboss/metadata/javaee/spec/ParamValueMetaData.java
+++ b/common/src/main/java/org/jboss/metadata/javaee/spec/ParamValueMetaData.java
@@ -50,6 +50,15 @@ public class ParamValueMetaData extends IdMetaDataImplWithDescriptions {
         this.paramValue = paramValue;
     }
 
+    public boolean validateParams() {
+        if (this.paramValue != null && this.paramName == null) {
+            return false;
+        } else if (this.paramValue == null && this.paramName != null) {
+            return false;
+        }
+        return true;
+    }
+
     @Override
     public String toString() {
         StringBuilder tmp = new StringBuilder("ParamValueMetaData(id=");

--- a/common/src/main/java/org/jboss/metadata/parser/ee/ParamValueMetaDataParser.java
+++ b/common/src/main/java/org/jboss/metadata/parser/ee/ParamValueMetaDataParser.java
@@ -83,6 +83,11 @@ public class ParamValueMetaDataParser extends MetaDataElementParser {
             }
         }
 
+        boolean validParams = paramValue.validateParams();
+        if (!validParams) {
+            throw new XMLStreamException("<param-name> OR <param-value> are not defined properly in pair inside the web.xml",reader.getLocation());
+        }
+
         return paramValue;
     }
 


### PR DESCRIPTION
...during deployment

https://issues.jboss.org/browse/WFLY-3699
