### PR TITLE
correct jboss-web-versionType value to 7.2 in jboss-web_7_2.xsd

### DIFF
--- a/web/src/main/resources/schema/jboss-web_7_2.xsd
+++ b/web/src/main/resources/schema/jboss-web_7_2.xsd
@@ -85,7 +85,7 @@
 
   <xsd:simpleType name="jboss-web-versionType">
       <xsd:restriction base="xsd:token">
-         <xsd:enumeration value="7.1"/>
+         <xsd:enumeration value="7.2"/>
       </xsd:restriction>
   </xsd:simpleType>
 


### PR DESCRIPTION
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1208338
The value of jboss-web-versionType in jboss-web_7_2.xsd file is incorrect