### PR TITLE
Bz 1192591

### DIFF
--- a/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
+++ b/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2011, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<xs:schema xmlns="urn:iiop" xmlns:javaee="http://java.sun.com/xml/ns/javaee"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           attributeFormDefault="unqualified" elementFormDefault="qualified"
+           targetNamespace="urn:iiop" version="1.0"
+           xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd">
+   <xs:import namespace="http://java.sun.com/xml/ns/javaee" schemaLocation="http://www.jboss.org/j2ee/schema/jboss-ejb3-spec-2_0.xsd"/>
+
+   <xs:element name="iiop" type="iiopConfigType" substitutionGroup="javaee:assembly-descriptor-entry"/>
+
+   <xs:complexType name="iiopConfigType">
+      <xs:complexContent>
+         <xs:extension base="javaee:jboss-assembly-descriptor-bean-entryType">
+            <xs:annotation>
+               <xs:documentation>
+                  <![CDATA[
+                  The iiop element contains the IIOP settings that are to be applied to an EJB. It must identify the
+                  bean to which the settings apply via the ejb-name sub-element. A wildcard "*" is allowed to convey
+                  that the settings are to be applied to all EJBs in the deployment.
+
+                  The binding-name sub-element can be used to specify the name that must be used to bind the EJB IOR
+                  in the COSNaming service. If a wildcard "*" is used as bean-name, this setting is ignored.
+
+                  The ior-security-config sub-element contains the security settings that are to be inserted into the
+                  EJB IOR. These include transport config requirements, authentication service settings, and secure
+                  attribute service settings. If a wildcard "*" is used as bean-name, the IOR settings will be applied
+                  to all beans in the deployment, except for the ones that override these settings in their own iiop
+                  element.
+                  ]]>
+               </xs:documentation>
+            </xs:annotation>
+            <xs:sequence>
+               <xs:element name="ejb-name" type="javaee:ejb-nameType" minOccurs="1" maxOccurs="1"/>
+               <xs:element name="binding-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
+               <xs:element name="ior-security-config" type="iorSecurityConfigType"/>
+            </xs:sequence>
+         </xs:extension>
+      </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="iorSecurityConfigType">
+      <xs:annotation>
+         <xs:documentation>
+             <![CDATA[
+             The iorSecurityConfigType specifies the elements that can be used to configure security constraints of IIOP
+             enabled EJB3 beans.
+
+             - transport-config: contains the attributes that are used to specify the transport security requirements.
+             - as-context: contains the attributes that are used to configure the authentication service (AS) context.
+             - sas-context: contains the attributes that are used to configure the security attribute service (SAS) context.
+                     ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:sequence>
+         <xs:element name="transport-config" type="iorTransportConfigType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="as-context" type="iorASContextType" minOccurs="0" maxOccurs="1"/>
+         <xs:element name="sas-context" type="iorSASContextType" minOccurs="0" maxOccurs="1"/>
+      </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="iorTransportConfigType">
+      <xs:annotation>
+         <xs:documentation>
+             <![CDATA[
+             The iorTransportConfigType specifies attributes that can be used to configure the transport requirements of
+             an IIOP enabled EJB3 bean.
+
+             * integrity: indicates if the server (target) supports integrity protected messages. The valid values are
+                          NONE, SUPPORTED or REQUIRED.
+             * confidentiality: indicates if the server (target) supports privacy protected messages. The values are
+                          NONE, SUPPORTED or REQUIRED.
+             * detect-misordering: indicates if the server (target) supports detection of message sequence errors. The
+                          values are NONE, SUPPORTED or REQUIRED.
+             * detect-replay: indicates if the server (target) supports detection of message replay attempts. The values
+                          are NONE, SUPPORTED or REQUIRED.
+             * establish-trust-in-client: indicates if the target is capable of authenticating a client. The values are
+                          NONE, SUPPORTED or REQUIRED.
+             * establish-trust-in-target: indicates if the target is capable of authenticating to a client. The values
+                         are NONE or SUPPORTED.
+                     ]]>
+         </xs:documentation>
+      </xs:annotation>
+      <xs:attribute name="integrity" type="xs:string" use="required"/>
+      <xs:attribute name="confidentiality" type="xs:string" use="required"/>
+      <xs:attribute name="detect-misordering" type="xs:string" use="optional" default="NONE"/>
+      <xs:attribute name="detect-replay" type="xs:string" use="optional" default="NONE"/>
+      <xs:attribute name="establish-trust-in-client" type="xs:string" use="required"/>
+      <xs:attribute name="establish-trust-in-target" type="xs:string" use="required"/>
+   </xs:complexType>
+    
+    <xs:complexType name="iorASContextType">
+       <xs:annotation>
+          <xs:documentation>
+              <![CDATA[
+              The iorASConfigType specifies attributes that can be used to configure the authentication service (AS) context.
+
+              * auth-method:describes the authentication method. The only supported values are USERNAME_PASSWORD and NONE.
+              * realm: describes the realm in which the user is authenticated. Must be a valid realm that is registered
+                       in server configuration.
+              * required: specifies if the supplied authentication method is required to be used for client authentication.
+                       If so the EstablishTrustInClient bit will be set in the target_requires field of the AS_Context.
+                       The attribute value is either true or false.
+                      ]]>
+          </xs:documentation>
+       </xs:annotation>
+       <xs:attribute name="auth-method" type="xs:string" use="required"/>
+       <xs:attribute name="realm" type="xs:string" use="required"/>
+       <xs:attribute name="required" type="xs:string" use="required"/>
+    </xs:complexType>
+
+    <xs:complexType name="iorSASContextType">
+       <xs:annotation>
+          <xs:documentation>
+              <![CDATA[
+              The iorASConfigType specifies attributes that can be used to configure the security attribute service.
+
+              * caller-propagation: indicates if the target will accept propagated caller identities The values are
+                       NONE or SUPPORTED.
+                      ]]>
+          </xs:documentation>
+       </xs:annotation>
+       <xs:attribute name="caller-propagation" type="xs:string" use="required"/>
+    </xs:complexType>
+
+</xs:schema>

--- a/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
+++ b/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
@@ -56,8 +56,6 @@
                </xs:documentation>
             </xs:annotation>
             <xs:sequence>
-               <!--Should not be provided, BZ-1192951 -->
-               <xs:element name="ejb-name" type="xs:string" minOccurs="0" maxOccurs="0"/>
                <xs:element name="binding-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                <xs:element name="ior-security-config" type="iorSecurityConfigType"/>
             </xs:sequence>

--- a/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
+++ b/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
@@ -53,7 +53,6 @@
                </xs:documentation>
             </xs:annotation>
             <xs:sequence>
-               <xs:element name="ejb-name" type="javaee:ejb-nameType" minOccurs="1" maxOccurs="1"/>
                <xs:element name="binding-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                <xs:element name="ior-security-config" type="iorSecurityConfigType"/>
             </xs:sequence>

--- a/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
+++ b/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
@@ -56,8 +56,8 @@
                </xs:documentation>
             </xs:annotation>
             <xs:sequence>
-              <!--Should not be provided, BZ-1192951 -->
-              <xs:element name="ejb-name" type="xs:string" minOccurs="0" maxOccurs="0"/>
+               <!--Should not be provided, BZ-1192951 -->
+               <xs:element name="ejb-name" type="xs:string" minOccurs="0" maxOccurs="0"/>
                <xs:element name="binding-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                <xs:element name="ior-security-config" type="iorSecurityConfigType"/>
             </xs:sequence>

--- a/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
+++ b/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
@@ -49,10 +49,15 @@
                   attribute service settings. If a wildcard "*" is used as bean-name, the IOR settings will be applied
                   to all beans in the deployment, except for the ones that override these settings in their own iiop
                   element.
+
+                  Prior to this version, ejb-name was a member of the iiopConfigType which was in error. ejb-name is provided
+                  as part of the extension base, jboss-assembly-descriptor-bean-entrytype.
                   ]]>
                </xs:documentation>
             </xs:annotation>
             <xs:sequence>
+              <!--Should not be provided, BZ-1192951 -->
+              <xs:element name="ejb-name" type="xs:string" minOccurs="0" maxOccurs="0"/>
                <xs:element name="binding-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                <xs:element name="ior-security-config" type="iorSecurityConfigType"/>
             </xs:sequence>
@@ -109,7 +114,7 @@
       <xs:attribute name="establish-trust-in-client" type="xs:string" use="required"/>
       <xs:attribute name="establish-trust-in-target" type="xs:string" use="required"/>
    </xs:complexType>
-    
+
     <xs:complexType name="iorASContextType">
        <xs:annotation>
           <xs:documentation>


### PR DESCRIPTION
Removed ejb-name from IIOP element as it already exists in jboss-assembly-descriptor-bean-entryType and substituion should provide the ejb-name. No duplication necessary.
