### PR TITLE
Removing ejb-name from iiopConfigType

### DIFF
--- a/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
+++ b/ejb/src/main/resources/schema/jboss-ejb-iiop_1_0.xsd
@@ -53,7 +53,6 @@
                </xs:documentation>
             </xs:annotation>
             <xs:sequence>
-               <xs:element name="ejb-name" type="javaee:ejb-nameType" minOccurs="1" maxOccurs="1"/>
                <xs:element name="binding-name" type="xs:string" minOccurs="0" maxOccurs="1"/>
                <xs:element name="ior-security-config" type="iorSecurityConfigType"/>
             </xs:sequence>
@@ -110,7 +109,7 @@
       <xs:attribute name="establish-trust-in-client" type="xs:string" use="required"/>
       <xs:attribute name="establish-trust-in-target" type="xs:string" use="required"/>
    </xs:complexType>
-    
+
     <xs:complexType name="iorASContextType">
        <xs:annotation>
           <xs:documentation>


### PR DESCRIPTION
Other BZ's depend on having the ejb-name element removed from the iiopConfigType element as it's causing issues because it is already provided in the parent element jboss-assembly-descriptor-bean-entryType which is in the jboss-ejb3-spec-2_0.xsd schema. 
https://issues.jboss.org/browse/JBMETA-388