### PR TITLE
fix the description of <cache-name>

### DIFF
--- a/web/src/main/resources/schema/jboss-web_10_0.xsd
+++ b/web/src/main/resources/schema/jboss-web_10_0.xsd
@@ -424,15 +424,15 @@
                 <xsd:documentation>
                     <![CDATA[
 
-                    Clustering only: Specifies the name of the Infinispan container/cache in which to store session data.
+                    Clustering only: Specifies the name of the Infinispan container and cache in which to store session data.
 
                     Default value, if not explicitly set, is determined by the application server.
 
-                    To use a specific cache within a cache container, use the form "container/cache".
+                    To use a specific cache within a cache container, use the form "container.cache".
                     If unqualified, the default cache of the specified container is used.
 
                     e.g. <cache-name>web</cache-name>
-                         <cache-name>web/dist</cache-name>
+                         <cache-name>web.dist</cache-name>
 
                     ]]>
                 </xsd:documentation>

--- a/web/src/main/resources/schema/jboss-web_7_0.xsd
+++ b/web/src/main/resources/schema/jboss-web_7_0.xsd
@@ -325,12 +325,15 @@
          <xsd:documentation>
             <![CDATA[
 
-            Clustering only: Name of the JBoss Cache or PojoCache configuration that 
-            should be used for storing distributable sessions and replicating them around the
-            cluster.
-        
-            Default value if not explicitly set is the overall web container default
-            as set in the deployers/jbossweb.deployer service.
+            Clustering only: Specifies the name of the Infinispan container and cache in which to store session data.
+
+            Default value, if not explicitly set, is determined by the application server.
+
+            To use a specific cache within a cache container, use the form "container.cache".
+            If unqualified, the default cache of the specified container is used.
+
+            e.g. <cache-name>web</cache-name>
+                 <cache-name>web.dist</cache-name>
 
             ]]>
          </xsd:documentation>

--- a/web/src/main/resources/schema/jboss-web_7_1.xsd
+++ b/web/src/main/resources/schema/jboss-web_7_1.xsd
@@ -337,12 +337,15 @@
          <xsd:documentation>
             <![CDATA[
 
-            Clustering only: Name of the JBoss Cache or PojoCache configuration that
-            should be used for storing distributable sessions and replicating them around the
-            cluster.
+            Clustering only: Specifies the name of the Infinispan container and cache in which to store session data.
 
-            Default value if not explicitly set is the overall web container default
-            as set in the deployers/jbossweb.deployer service.
+            Default value, if not explicitly set, is determined by the application server.
+
+            To use a specific cache within a cache container, use the form "container.cache".
+            If unqualified, the default cache of the specified container is used.
+
+            e.g. <cache-name>web</cache-name>
+                 <cache-name>web.dist</cache-name>
 
             ]]>
          </xsd:documentation>

--- a/web/src/main/resources/schema/jboss-web_8_0.xsd
+++ b/web/src/main/resources/schema/jboss-web_8_0.xsd
@@ -411,15 +411,15 @@
                 <xsd:documentation>
                     <![CDATA[
 
-                    Clustering only: Specifies the name of the Infinispan container/cache in which to store session data.
+                    Clustering only: Specifies the name of the Infinispan container and cache in which to store session data.
 
                     Default value, if not explicitly set, is determined by the application server.
 
-                    To use a specific cache within a cache container, use the form "container/cache".
+                    To use a specific cache within a cache container, use the form "container.cache".
                     If unqualified, the default cache of the specified container is used.
 
                     e.g. <cache-name>web</cache-name>
-                         <cache-name>web/dist</cache-name>
+                         <cache-name>web.dist</cache-name>
 
                     ]]>
                 </xsd:documentation>


### PR DESCRIPTION
Updated jboss-web_{8,10}_0.xsd to fix the \<cache-name\> format
and to align with shared-session-config_1_0.xsd from WildFly.

Updated jboss-web_7_{0,1}.xsd, because it contained obsolete
description from AS6.