### PR TITLE
JBMETA-384 - fix jboss-web_8_0.xsd to use proper name space 

### DIFF
--- a/web/src/main/resources/schema/jboss-web_8_0.xsd
+++ b/web/src/main/resources/schema/jboss-web_8_0.xsd
@@ -72,7 +72,8 @@
          consistency with the Servlet API. </xsd:documentation>
    </xsd:annotation>
 
-   <xsd:import namespace="http://java.sun.com/xml/ns/javaee" schemaLocation="web-app_3_1.xsd"/>
+   <xsd:import namespace="http://xmlns.jcp.org/xml/ns/javaee" schemaLocation="http://www.jboss.org/schema/jbossas/web-app_3_1.xsd"/>
+   <xsd:include schemaLocation="http://www.jboss.org/schema/jbossas/jboss-common_6_0.xsd"/>
 
    <xsd:element name="jboss-web" type="jboss:jboss-webType">
       <xsd:annotation>


### PR DESCRIPTION
JBMETA-384 - fix jboss-web_8_0.xsd to use proper name space and not use relative-path schemaLocation.
