### PR TITLE
fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-    - openjdk7
+    - oraclejdk8


### PR DESCRIPTION
Travis for now do not support openjdk8, that's why oraclejdk8 is used.