### PR TITLE
[JBMETA-398] The jboss-web_7_1.xsd and 7.2.xsd file cause validation errors in Eclipse

### DIFF
--- a/web/src/main/resources/schema/jboss-web_7_1.xsd
+++ b/web/src/main/resources/schema/jboss-web_7_1.xsd
@@ -250,16 +250,14 @@
       </xsd:simpleContent>
    </xsd:complexType>
 
-   <xsd:complexType name="symbolic-linked-allowedType">
+   <xsd:simpleType name="symbolic-linked-allowedType">
        <xsd:annotation>
           <xsd:documentation>
              Thesymbolic-linked-allowed element specifies if symlinking is allowed in exploded deployments.
           </xsd:documentation>
        </xsd:annotation>
-       <xsd:simpleContent>
-          <xsd:restriction base="xsd:boolean"/>
-       </xsd:simpleContent>
-   </xsd:complexType>
+       <xsd:restriction base="xsd:boolean"/>
+   </xsd:simpleType>
 
    <xsd:complexType name="jacc-star-role-allowType">
       <xsd:annotation>

--- a/web/src/main/resources/schema/jboss-web_7_2.xsd
+++ b/web/src/main/resources/schema/jboss-web_7_2.xsd
@@ -251,16 +251,14 @@
       </xsd:simpleContent>
    </xsd:complexType>
 
-   <xsd:complexType name="symbolic-linked-allowedType">
+   <xsd:simpleType name="symbolic-linked-allowedType">
        <xsd:annotation>
           <xsd:documentation>
              Thesymbolic-linked-allowed element specifies if symlinking is allowed in exploded deployments.
           </xsd:documentation>
        </xsd:annotation>
-       <xsd:simpleContent>
-          <xsd:restriction base="xsd:boolean"/>
-       </xsd:simpleContent>
-   </xsd:complexType>
+       <xsd:restriction base="xsd:boolean"/>
+   </xsd:simpleType>
 
    <xsd:complexType name="jacc-star-role-allowType">
       <xsd:annotation>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBMETA-398

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1208342