### PR TITLE
Revert changes made w.r.t. JDK 9

### DIFF
--- a/build-config/src/main/resources/metadata-checkstyle/checkstyle.xml
+++ b/build-config/src/main/resources/metadata-checkstyle/checkstyle.xml
@@ -52,12 +52,18 @@
         <module name="ModifierOrder"/>
         <module name="RedundantModifier"/>
 
+        <!-- Checks for blocks. You know, those {}'s         -->
+        <module name="LeftCurly"/>
+
         <!-- Checks for common coding problems               -->
         <!-- Disabled until http://sourceforge.net/tracker/?func=detail&aid=2843447&group_id=29721&atid=397078 is fixed-->
         <!--<module name="DoubleCheckedLocking"/>-->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="IllegalInstantiation"/>
+        <module name="RedundantThrows">
+            <property name="allowUnchecked" value="true"/>
+        </module>
 
         <!-- Miscellaneous other checks.                   -->
         <module name="UpperEll"/>

--- a/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
+++ b/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
@@ -640,7 +640,7 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         private final String baseURI;
         private final InputSource inputSource;
 
-        LSInputImpl(String publicID, String systemID, String baseURI, InputSource inputSource) {
+        public LSInputImpl(String publicID, String systemID, String baseURI, InputSource inputSource) {
             this.inputSource = inputSource;
             this.systemID = systemID;
             this.publicID = publicID;

--- a/ejb/src/main/java/org/jboss/metadata/ejb/parser/jboss/ejb3/IIOPMetaDataParser.java
+++ b/ejb/src/main/java/org/jboss/metadata/ejb/parser/jboss/ejb3/IIOPMetaDataParser.java
@@ -272,7 +272,7 @@ public class IIOPMetaDataParser extends AbstractEJBBoundMetaDataParser<IIOPMetaD
          *
          * @param namespaceURI a {@code String} representing the namespace {@code URI}.
          */
-        Namespace(final String namespaceURI) {
+        private Namespace(final String namespaceURI) {
             this.namespaceURI = namespaceURI;
         }
 

--- a/ejb/src/main/java/org/jboss/metadata/ejb/parser/spec/TimerMetaDataParser.java
+++ b/ejb/src/main/java/org/jboss/metadata/ejb/parser/spec/TimerMetaDataParser.java
@@ -22,10 +22,11 @@
 
 package org.jboss.metadata.ejb.parser.spec;
 
-import java.time.ZonedDateTime;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.Calendar;
-import java.util.GregorianCalendar;
 
+import javax.xml.bind.DatatypeConverter;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
@@ -126,7 +127,35 @@ public class TimerMetaDataParser extends AbstractMetaDataParser<TimerMetaData> {
 
         }
     }
+
+    //TODO: get rid of the javax.xml.bind reference
+    //TODO: because of CL issues we need to set the CL or DatatypeConverter will fail
     private static Calendar parseDateTime(String dateTime) {
-        return GregorianCalendar.from(ZonedDateTime.parse(dateTime));
+        final ClassLoader o = getTccl();
+        try {
+            setTccl(TimerMetaDataParser.class.getClassLoader());
+            return DatatypeConverter.parseDateTime(dateTime);
+        } finally {
+            setTccl(o);
+        }
+    }
+
+    private static ClassLoader getTccl() {
+        return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            @Override
+            public ClassLoader run() {
+                return Thread.currentThread().getContextClassLoader();
+            }
+        });
+    }
+
+    private static void setTccl(final ClassLoader classLoader) {
+        AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+            @Override
+            public ClassLoader run() {
+                Thread.currentThread().setContextClassLoader(classLoader);
+                return null;
+            }
+        });
     }
 }

--- a/ejb/src/test/java/org/jboss/test/metadata/annotation/ejb3/MyStatefulBean.java
+++ b/ejb/src/test/java/org/jboss/test/metadata/annotation/ejb3/MyStatefulBean.java
@@ -35,6 +35,7 @@ import javax.ejb.Remove;
 import javax.ejb.SessionContext;
 import javax.ejb.Stateful;
 import javax.persistence.PersistenceContext;
+import javax.xml.ws.WebServiceRef;
 
 import org.jboss.ejb3.annotation.Clustered;
 
@@ -67,6 +68,7 @@ public class MyStatefulBean {
     @PersistenceContext
     private String string;
 
+    @WebServiceRef
     private MyStateful webserviceRef;
 
     @PostConstruct

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>21</version>
+        <version>11</version>
     </parent>
 
     <groupId>org.jboss.metadata</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -46,8 +46,8 @@
         <javax.persistence.version>1.0.0.Final</javax.persistence.version>
 
         <!-- Build configuration -->
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
         <maven.min.version>3.0.4</maven.min.version>
 
         <!-- Dependency versions. Please keep alphabetical -->


### PR DESCRIPTION
With or without these changes, compiling with JDK 9 currently does not work anyway.

The actual change also causes a regression as mentioned in https://issues.jboss.org/browse/JBEAP-9670.