### PR TITLE
JBMETA-400: ensure using the new time API works correctly for ISO 8601 dates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: java
 jdk:
-    - openjdk7
+    - oraclejdk8

--- a/ejb/src/main/java/org/jboss/metadata/ejb/parser/spec/TimerMetaDataParser.java
+++ b/ejb/src/main/java/org/jboss/metadata/ejb/parser/spec/TimerMetaDataParser.java
@@ -22,13 +22,6 @@
 
 package org.jboss.metadata.ejb.parser.spec;
 
-import java.time.ZonedDateTime;
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-
 import org.jboss.metadata.ejb.spec.NamedMethodMetaData;
 import org.jboss.metadata.ejb.spec.ScheduleMetaData;
 import org.jboss.metadata.ejb.spec.TimerMetaData;
@@ -36,6 +29,18 @@ import org.jboss.metadata.javaee.spec.DescriptionGroupMetaData;
 import org.jboss.metadata.parser.ee.Accessor;
 import org.jboss.metadata.parser.ee.DescriptionGroupMetaDataParser;
 import org.jboss.metadata.property.PropertyReplacer;
+
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.TemporalAccessor;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+import static java.time.temporal.ChronoField.OFFSET_SECONDS;
 
 /**
  * Parses and creates metadata out of &lt;timer&gt; element in ejb-jar.xml
@@ -58,6 +63,18 @@ public class TimerMetaDataParser extends AbstractMetaDataParser<TimerMetaData> {
         TimerMetaData timerMetaData = new TimerMetaData();
         this.processElements(timerMetaData, reader, propertyReplacer);
         return timerMetaData;
+    }
+
+    private static Calendar parseDateTime(String dateTime) {
+        final TemporalAccessor ta = DateTimeFormatter.ISO_DATE_TIME.parse(dateTime);
+        final LocalDateTime localDateTime = LocalDateTime.from(ta);
+        final ZoneId zoneId;
+        if (ta.isSupported(OFFSET_SECONDS)) {
+            zoneId = ZoneId.from(ta);
+        } else {
+            zoneId = ZoneId.systemDefault();
+        }
+        return GregorianCalendar.from(ZonedDateTime.of(localDateTime, zoneId));
     }
 
     /**
@@ -125,8 +142,5 @@ public class TimerMetaDataParser extends AbstractMetaDataParser<TimerMetaData> {
                 throw unexpectedElement(reader);
 
         }
-    }
-    private static Calendar parseDateTime(String dateTime) {
-        return GregorianCalendar.from(ZonedDateTime.parse(dateTime));
     }
 }

--- a/ejb/src/test/java/org/jboss/metadata/ejb/test/jbmeta400/ISO8601TestCase.java
+++ b/ejb/src/test/java/org/jboss/metadata/ejb/test/jbmeta400/ISO8601TestCase.java
@@ -1,0 +1,78 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright (c) 2017, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.jboss.metadata.ejb.test.jbmeta400;
+
+import org.jboss.metadata.ejb.spec.EjbJarMetaData;
+import org.jboss.metadata.ejb.spec.SessionBean31MetaData;
+import org.jboss.metadata.ejb.test.common.UnmarshallingHelper;
+import org.junit.Test;
+
+import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author <a href="mailto:cdewolf@redhat.com">Carlo de Wolf</a>
+ */
+public class ISO8601TestCase {
+    @Test
+    public void testParse() throws Exception {
+        final EjbJarMetaData ejbJarMetaData = UnmarshallingHelper.unmarshal(EjbJarMetaData.class, "/org/jboss/metadata/ejb/test/jbmeta400/ejb-jar.xml");
+        final SessionBean31MetaData bean = (SessionBean31MetaData) ejbJarMetaData.getEnterpriseBean("Test");
+        {
+            final Calendar start = bean.getTimers().get(0).getStart();
+            assertEquals(1990, start.get(Calendar.YEAR));
+            assertEquals(Calendar.JANUARY, start.get(Calendar.MONTH));
+            assertEquals(1, start.get(Calendar.DAY_OF_MONTH));
+            assertEquals(0, start.get(Calendar.HOUR_OF_DAY));
+            assertEquals(0, start.get(Calendar.MINUTE));
+            assertEquals(0, start.get(Calendar.SECOND));
+            // the ZONE_OFFSET should be equal to the system default, should we check this?
+            final Calendar end = bean.getTimers().get(0).getEnd();
+            assertEquals(9000, end.get(Calendar.YEAR));
+            assertEquals(Calendar.DECEMBER, end.get(Calendar.MONTH));
+            assertEquals(31, end.get(Calendar.DAY_OF_MONTH));
+            assertEquals(0, end.get(Calendar.HOUR_OF_DAY));
+            assertEquals(0, end.get(Calendar.MINUTE));
+            assertEquals(0, end.get(Calendar.SECOND));
+        }
+        {
+            final Calendar start = bean.getTimers().get(1).getStart();
+            assertEquals(1990, start.get(Calendar.YEAR));
+            assertEquals(Calendar.FEBRUARY, start.get(Calendar.MONTH));
+            assertEquals(2, start.get(Calendar.DAY_OF_MONTH));
+            assertEquals(12, start.get(Calendar.HOUR_OF_DAY));
+            assertEquals(34, start.get(Calendar.MINUTE));
+            assertEquals(56, start.get(Calendar.SECOND));
+            assertEquals(TimeUnit.HOURS.toMillis(2), start.get(Calendar.ZONE_OFFSET));
+            final Calendar end = bean.getTimers().get(1).getEnd();
+            assertEquals(9000, end.get(Calendar.YEAR));
+            assertEquals(Calendar.DECEMBER, end.get(Calendar.MONTH));
+            assertEquals(31, end.get(Calendar.DAY_OF_MONTH));
+            assertEquals(0, end.get(Calendar.HOUR_OF_DAY));
+            assertEquals(0, end.get(Calendar.MINUTE));
+            assertEquals(0, end.get(Calendar.SECOND));
+            assertEquals(TimeUnit.HOURS.toMillis(2), start.get(Calendar.ZONE_OFFSET));
+        }
+    }
+}

--- a/ejb/src/test/resources/org/jboss/metadata/ejb/test/jbmeta400/ejb-jar.xml
+++ b/ejb/src/test/resources/org/jboss/metadata/ejb/test/jbmeta400/ejb-jar.xml
@@ -1,0 +1,46 @@
+<!--
+  ~ JBoss, Home of Professional Open Source.
+  ~ Copyright (c) 2017, Red Hat, Inc., and individual contributors
+  ~ as indicated by the @author tags. See the copyright.txt file in the
+  ~ distribution for a full listing of individual contributors.
+  ~
+  ~ This is free software; you can redistribute it and/or modify it
+  ~ under the terms of the GNU Lesser General Public License as
+  ~ published by the Free Software Foundation; either version 2.1 of
+  ~ the License, or (at your option) any later version.
+  ~
+  ~ This software is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ Lesser General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU Lesser General Public
+  ~ License along with this software; if not, write to the Free
+  ~ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+  ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+  -->
+<ejb-jar version="3.1" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd">
+    <enterprise-beans>
+        <session>
+            <ejb-name>Test</ejb-name>
+            <timer>
+                <schedule></schedule>
+                <start>1990-01-01T00:00:00</start>
+                <end>9000-12-31T00:00:00</end>
+                <timeout-method>
+                    <method-name>timer</method-name>
+                </timeout-method>
+            </timer>
+            <timer>
+                <schedule></schedule>
+                <start>1990-02-02T12:34:56+02:00</start>
+                <end>9000-12-31T00:00:00+02:00</end>
+                <timeout-method>
+                    <method-name>timerOffset</method-name>
+                </timeout-method>
+            </timer>
+        </session>
+    </enterprise-beans>
+</ejb-jar>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>21</version>
+        <version>11</version>
     </parent>
 
     <groupId>org.jboss.metadata</groupId>


### PR DESCRIPTION
https://issues.jboss.org/browse/JBMETA-400

Ensures the fault as mentioned in https://issues.jboss.org/browse/JBEAP-9670 does not occur.