### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
 jdk:
-    - oraclejdk8
-    - oraclejdk9
+  - oraclejdk11
+install:  
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -Dcommunity -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2
+script:
+  - mvn test -B -Dcommunity -Dhttps.protocols=TLSv1,TLSv1.1,TLSv1.2


### PR DESCRIPTION
JDK 8 is no longer a valid version, see:
```

Expected feature release number in range of 9 to 15, but got: 8

The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during .

Your build has been stop
```
LTS JDK 11 has a bug https://bugs.openjdk.java.net/browse/JDK-8213202, have to configure https.protocols as a workaround.