### PR TITLE
[JBMETA-420] Add the EE 9 spec xsds

### DIFF
--- a/appclient/src/main/resources/schema/application-client_9.xsd
+++ b/appclient/src/main/resources/schema/application-client_9.xsd
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="9">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application client 9
+      deployment descriptor.  The deployment descriptor must
+      be named "META-INF/application-client.xml" in the
+      application client's jar file.  All application client
+      deployment descriptors must indicate the application
+      client schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd"
+      version="9">
+      ...
+      </application-client>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="application-client"
+               type="jakartaee:application-clientType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The application-client element is the root element of an
+        application client deployment descriptor.  The application
+        client deployment descriptor describes the enterprise bean 
+        components and external resources referenced by the 
+        application client.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of an
+          application client's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name must
+          be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:unique name="ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an enterprise bean 
+          reference. The enterprise bean reference is an entry 
+          in the application client's environment and is relative to the
+          java:comp/env context. The name must be unique within the
+          application client.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the application client
+          code. The name is a JNDI name relative to the
+          java:comp/env context and must be unique within an
+          application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the
+          name of a message destination reference; its value is
+          the message destination reference name used in the
+          application client code. The name is a JNDI name
+          relative to the java:comp/env context and must be unique
+          within an application client.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="application-clientType">
+    <xsd:sequence>
+      <xsd:element name="module-name"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="env-entry"
+                   type="jakartaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="jakartaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="jakartaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="jakartaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="jakartaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="jakartaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="callback-handler"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The callback-handler element names a class provided by
+            the application.  The class must have a no args
+            constructor and must implement the
+            jakarta.security.auth.callback.CallbackHandler
+            interface.  The class will be instantiated by the
+            application client container and used by the container
+            to collect authentication information from the user.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination"
+                   type="jakartaee:message-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="jakartaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="jakartaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="jakartaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="jakartaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="jakartaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="jakartaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="9"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 9.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          deployment descriptor and other related deployment
+          descriptors for this module (e.g., web service
+          descriptors) are complete, or whether the class
+          files available to this module and packaged with
+          this application should be examined for annotations
+          that specify deployment information.
+          
+          If metadata-complete is set to "true", the deployment
+          tool must ignore any annotations that specify deployment
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the deployment tool must examine the class
+          files of the application for annotations, as
+          specified by the specifications.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
+++ b/common/src/main/java/org/jboss/metadata/parser/util/XMLResourceResolver.java
@@ -97,6 +97,8 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://java.sun.com/xml/ns/javaee/application_5.xsd", "application_5.xsd");
         registerEntity("http://java.sun.com/xml/ns/javaee/application_6.xsd", "application_6.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/application_7.xsd", "application_7.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/application_8.xsd", "application_8.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/application_9.xsd", "application_9.xsd");
         // jboss-app
         registerEntity("-//JBoss//DTD J2EE Application 1.3//EN", "jboss-app_3_0.dtd");
         registerEntity("-//JBoss//DTD J2EE Application 1.3V2//EN", "jboss-app_3_2.dtd");
@@ -109,6 +111,8 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://java.sun.com/xml/ns/javaee/application-client_5.xsd", "application-client_5.xsd");
         registerEntity("http://java.sun.com/xml/ns/javaee/application-client_6.xsd", "application-client_6.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/application-client_7.xsd", "application-client_7.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/application-client_8.xsd", "application-client_8.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd", "application-client_9.xsd");
         // jboss-client
         registerEntity("-//JBoss//DTD Application Client 3.2//EN", "jboss-client_3_2.dtd");
         registerEntity("-//JBoss//DTD Application Client 4.0//EN", "jboss-client_4_0.dtd");
@@ -140,6 +144,7 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://java.sun.com/xml/ns/javaee/ejb-jar_3_0.xsd", "ejb-jar_3_0.xsd");
         registerEntity("http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd", "ejb-jar_3_1.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd", "ejb-jar_3_2.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd", "ejb-jar_4_0.xsd");
         // jboss ejb2
         registerEntity("-//JBoss//DTD JBOSS//EN", "jboss.dtd");
         registerEntity("-//JBoss//DTD JBOSS 2.4//EN", "jboss_2_4.dtd");
@@ -163,6 +168,8 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://java.sun.com/xml/ns/javaee/javaee_5.xsd", "javaee_5.xsd");
         registerEntity("http://java.sun.com/xml/ns/javaee/javaee_6.xsd", "javaee_6.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/javaee_7.xsd", "javaee_7.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/javaee_8.xsd", "javaee_8.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/jakartaee_9.xsd", "jakartaee_9.xsd");
         // JBoss common
         registerEntity("https://www.jboss.org/j2ee/schema/jboss-common_5_1.xsd", "jboss-common_5_1.xsd");
 
@@ -176,13 +183,17 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://java.sun.com/xml/ns/javaee/javaee_web_services_1_3.xsd", "javaee_web_services_1_3.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/javaee_web_services_client_1_4.xsd", "javaee_web_services_client_1_4.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/javaee_web_services_1_4.xsd", "javaee_web_services_1_4.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/jakartaee_web_services_client_2_0.xsd", "jakartaee_web_services_client_2_0.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/jakartaee_web_services_2_0.xsd", "jakartaee_web_services_2_0.xsd");
 
         // jsp
         registerEntity("http://java.sun.com/xml/ns/javaee/jsp_2_2.xsd", "jsp_2_2.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/jsp_2_3.xsd", "jsp_2_3.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/jsp_3_0.xsd", "jsp_3_0.xsd");
 
         // permissions
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/permissions_7.xsd", "permissions_7.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd", "permissions_9.xsd");
 
         // web
         registerEntity("-//Sun Microsystems, Inc.//DTD Web Application 2.2//EN", "web-app_2_2.dtd");
@@ -191,6 +202,28 @@ public class XMLResourceResolver implements XMLResolver, EntityResolver, LSResou
         registerEntity("http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd", "web-app_2_5.xsd");
         registerEntity("http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd", "web-app_3_0.xsd");
         registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd", "web-app_3_1.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd", "web-app_4_0.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd", "web-app_5_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-common_3_0.xsd", "web-common_3_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-common_3_1.xsd", "web-common_3_1.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-common_4_0.xsd", "web-common_4_0.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/web-common_5_0.xsd", "web-common_5_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-facelettaglibrary_2_2.xsd", "web-facelettaglibrary_2_2.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-facelettaglibrary_2_3.xsd", "web-facelettaglibrary_2_3.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibrary_3_0.xsd", "web-facelettaglibrary_3_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_1_2.xsd", "web-facesconfig_1_2.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-facesconfig_2_2.xsd", "web-facesconfig_2_2.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd", "web-facesconfig_3_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-fragment_3_0.xsd", "web-fragment_3_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-fragment_3_1.xsd", "web-fragment_3_1.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-fragment_4_0.xsd", "web-fragment_4_0.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/web-fragment_5_0.xsd", "web-fragment_5_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-jsptaglibrary_2_1.xsd", "web-jsptaglibrary_2_1.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd", "web-jsptaglibrary_3_0.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-partialresponse_2_2.xsd", "web-partialresponse_2_2.xsd");
+        registerEntity("http://xmlns.jcp.org/xml/ns/javaee/web-partialresponse_2_3.xsd", "web-partialresponse_2_3.xsd");
+        registerEntity("https://jakarta.ee/xml/ns/jakartaee/web-partialresponse_3_0.xsd", "web-partialresponse_3_0.xsd");
+
         // jboss-web
         registerEntity("-//JBoss//DTD Web Application 2.2//EN", "jboss-web.dtd");
         registerEntity("-//JBoss//DTD Web Application 2.3//EN", "jboss-web_3_0.dtd");

--- a/common/src/main/resources/schema/jakartaee_9.xsd
+++ b/common/src/main/resources/schema/jakartaee_9.xsd
@@ -1,0 +1,3073 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="8">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following definitions that appear in the common
+      shareable schema(s) of Jakarta EE deployment descriptors should be
+      interpreted with respect to the context they are included:
+      
+      Deployment Component may indicate one of the following:
+      Jakarta EE application;
+      application client;
+      web application;
+      enterprise bean;
+      resource adapter; 
+      
+      Deployment File may indicate one of the following:
+      ear file;
+      war file;
+      jar file;
+      rar file;
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+
+  <xsd:include schemaLocation="jakartaee_web_services_client_2_0.xsd"/>
+
+  <xsd:group name="descriptionGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained description related
+        elements consistent across Jakarta EE deployment descriptors.
+        
+        All elements may occur multiple times with different languages,
+        to support localization of the content.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="display-name"
+                   type="jakartaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="icon"
+                   type="jakartaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="jndiEnvironmentRefsGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group keeps the usage of the contained JNDI environment
+        reference elements consistent across Jakarta EE deployment descriptors.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="env-entry"
+                   type="jakartaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="jakartaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-local-ref"
+                   type="jakartaee:ejb-local-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="jakartaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="jakartaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="jakartaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref"
+                   type="jakartaee:persistence-context-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="jakartaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="post-construct"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-destroy"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="jakartaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="jakartaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="jakartaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="jakartaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="jakartaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="jakartaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to most
+        JNDI resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+      <xsd:element name="lookup-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve a resource reference.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+  <xsd:group name="resourceBaseGroup">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This group collects elements that are common to all the
+        JNDI resource elements. It does not include the lookup-name
+        element, that is only applicable to some resource elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="mapped-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this resource should be
+            mapped to.  The name of this resource, as defined by the
+            resource's name element or defaulted, is a name that is
+            local to the application component using the resource.
+            (It's a name in the JNDI java:comp/env namespace.)  Many
+            application servers provide a way to map these local
+            names to names of resources known to the application
+            server.  This mapped name is often a global JNDI name,
+            but may be a name of any form.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="injection-target"
+                   type="jakartaee:injection-targetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:group>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="administered-objectType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of an administered object.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this administered object.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            administered object being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's interface type.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The administered object's class name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Property of the administered object property.  This may be a 
+            vendor-specific property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="connection-factory-resourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Connector Connection Factory resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully qualified class name of the connection factory 
+            interface. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transaction-support"
+                   type="jakartaee:transaction-supportType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The level of transaction support the connection factory 
+            needs to support. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="data-sourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a DataSource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this DataSource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            data source being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            DataSource, XADataSource or ConnectionPoolDataSource
+            implementation class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="server-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Database server name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-number"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Port number where a server is listening for requests.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="database-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of a database on a server.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="url"
+                   type="jakartaee:jdbc-urlType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            A JDBC URL. If the <code>url</code> property is specified
+            along with other standard <code>DataSource</code> properties
+            such as <code>serverName</code>, <code>databaseName</code>
+            and <code>portNumber</code>, the more specific properties will
+            take precedence and <code>url</code> will be ignored.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            JDBC DataSource property.  This may be a vendor-specific
+            property or a less commonly used DataSource property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="login-timeout"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Sets the maximum time in seconds that this data source
+            will wait while attempting to connect to a database.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="jakartaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="isolation-level"
+                   type="jakartaee:isolation-levelType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Isolation level for connections.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="initial-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Number of connections that should be created when a
+            connection pool is initialized.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-idle-time"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The number of seconds that a physical connection should
+            remain unused in the pool before the connection is
+            closed for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-statements"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The total number of statements that a connection pool
+            should keep open.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The description type is used by a description element to
+        provide text describing the parent element.  The elements
+        that use this type should include any information that the
+        Deployment Component's Deployment File file producer wants
+        to provide to the consumer of the Deployment Component's
+        Deployment File (i.e., to the Deployer). Typically, the
+        tools used by such a Deployment File consumer will display
+        the description when processing the parent element that
+        contains the description.
+        
+        The lang attribute defines the language that the
+        description is provided in. The default value is "en" (English). 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:xsdStringType">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="dewey-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines a dewey decimal that is used
+        to describe versions of documents. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\.?[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="display-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The display-name type contains a short name that is intended
+        to be displayed by tools. It is used by display-name
+        elements.  The display name need not be unique.
+        
+        Example: 
+        
+        ...
+        <display-name xml:lang="en">
+        Employee Self Service
+        </display-name>
+        
+        The value of the xml:lang attribute is "en" (English) by default. 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:string">
+        <xsd:attribute ref="xml:lang"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-linkType is used by ejb-link
+        elements in the ejb-ref or ejb-local-ref elements to specify
+        that an enterprise bean reference is linked to enterprise bean.
+        
+        The value of the ejb-link element must be the ejb-name of an
+        enterprise bean in the same ejb-jar file or in another ejb-jar
+        file in the same Jakarta EE application unit. 
+        
+        Alternatively, the name in the ejb-link element may be
+        composed of a path name specifying the ejb-jar containing the
+        referenced enterprise bean with the ejb-name of the target
+        bean appended and separated from the path name by "#".  The
+        path name is relative to the Deployment File containing
+        Deployment Component that is referencing the enterprise
+        bean.  This allows multiple enterprise beans with the same
+        ejb-name to be uniquely identified.
+        
+        Examples:
+        
+        <ejb-link>EmployeeRecord</ejb-link>
+        
+        <ejb-link>../products/product.jar#ProductEJB</ejb-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-local-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-local-refType is used by ejb-local-ref elements for
+        the declaration of a reference to an enterprise bean's local
+        home or to the local business interface of a 3.0 bean.
+        The declaration consists of:
+        
+        - an optional description
+        - the enterprise bean's reference name used in the code of the 
+        Deployment Component that's referencing the enterprise bean.
+        - the optional expected type of the referenced enterprise bean
+        - the optional expected local interface of the referenced 
+        enterprise bean or the local business interface of the 
+        referenced enterprise bean.
+        - the optional expected local home interface of the referenced 
+        enterprise bean. Not applicable if this ejb-local-ref refers
+        to the local business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the 
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise  
+        bean into a component field or property.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="jakartaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="jakartaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="local-home"
+                   type="jakartaee:local-homeType"
+                   minOccurs="0"/>
+      <xsd:element name="local"
+                   type="jakartaee:localType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="jakartaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-ref-name element contains the name of an enterprise bean reference. 
+        The enterprise bean reference is an entry in the Deployment Component's 
+        environment and is relative to the java:comp/env context.  The name must 
+        be unique within the Deployment Component.
+        
+        It is recommended that name is prefixed with "ejb/".
+        
+        Example:
+        
+        <ejb-ref-name>ejb/Payroll</ejb-ref-name>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:jndi-nameType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-refType is used by ejb-ref elements for the
+        declaration of a reference to an enterprise bean's home or
+        to the remote business interface of a 3.0 bean.  
+        The declaration consists of:
+        
+        - an optional description
+        - the enterprise bean's reference name used in the code of
+        the Deployment Component that's referencing the enterprise
+        bean. 
+        - the optional expected type of the referenced enterprise bean
+        - the optional remote interface of the referenced enterprise bean
+        or the remote business interface of the referenced enterprise 
+        bean
+        - the optional expected home interface of the referenced 
+        enterprise bean.  Not applicable if this ejb-ref
+        refers to the remote business interface of a 3.0 bean.
+        - optional ejb-link information, used to specify the
+        referenced enterprise bean
+        - optional elements to define injection of the named enterprise
+        bean into a component field or property
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref-name"
+                   type="jakartaee:ejb-ref-nameType"/>
+      <xsd:element name="ejb-ref-type"
+                   type="jakartaee:ejb-ref-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="home"
+                   type="jakartaee:homeType"
+                   minOccurs="0"/>
+      <xsd:element name="remote"
+                   type="jakartaee:remoteType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-link"
+                   type="jakartaee:ejb-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-ref-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-ref-typeType contains the expected type of the
+        referenced enterprise bean.
+        
+        The ejb-ref-type designates a value
+        that must be one of the following:
+        
+        Entity
+        Session
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Entity"/>
+        <xsd:enumeration value="Session"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="emptyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is used to designate an empty
+        element when used. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The env-entryType is used to declare an application's
+        environment entry. The declaration consists of an optional
+        description, the name of the environment entry, a type
+        (optional if the value is injected, otherwise required), and
+        an optional value.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        If a value is not specified and injection is requested,
+        no injection will occur and no entry of the specified name
+        will be created.  This allows an initial value to be
+        specified in the source code without being incorrectly
+        changed when no override has been specified.
+        
+        If a value is not specified and no injection is requested,
+        a value must be supplied during deployment. 
+        
+        This type is used by env-entry elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="env-entry-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-name element contains the name of a
+            Deployment Component's environment entry.  The name
+            is a JNDI name relative to the java:comp/env
+            context.  The name must be unique within a 
+            Deployment Component. The uniqueness
+            constraints must be defined within the declared
+            context.
+            
+            Example:
+            
+            <env-entry-name>minAmount</env-entry-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-type"
+                   type="jakartaee:env-entry-type-valuesType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-type element contains the Java language
+            type of the environment entry.  If an injection target
+            is specified for the environment entry, the type may
+            be omitted, or must match the type of the injection
+            target.  If no injection target is specified, the type
+            is required.
+            
+            Example:
+            
+            <env-entry-type>java.lang.Integer</env-entry-type>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry-value"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The env-entry-value designates the value of a
+            Deployment Component's environment entry. The value
+            must be a String that is valid for the
+            constructor of the specified type that takes a
+            single String parameter, or for java.lang.Character,
+            a single character.
+            
+            Example:
+            
+            <env-entry-value>100.00</env-entry-value>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="env-entry-type-valuesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        This type contains the fully-qualified Java type of the
+        environment entry value that is expected by the
+        application's code.
+        
+        The following are the legal values of env-entry-type-valuesType:
+        
+        java.lang.Boolean
+        java.lang.Byte
+        java.lang.Character
+        java.lang.String
+        java.lang.Short
+        java.lang.Integer
+        java.lang.Long
+        java.lang.Float
+        java.lang.Double
+        		  java.lang.Class
+        		  any enumeration type (i.e. a subclass of java.lang.Enum)
+        
+        Examples:
+        
+        <env-entry-type>java.lang.Boolean</env-entry-type>
+        <env-entry-type>java.lang.Class</env-entry-type>
+        <env-entry-type>com.example.Color</env-entry-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="fully-qualified-classType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate the name of a
+        Java class or interface.  The name is in the form of a
+        "binary name", as defined in the JLS.  This is the form
+        of name used in Class.forName().  Tools that need the
+        canonical name (the name used in source code) will need
+        to convert this binary name to the canonical name.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="generic-booleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines four different values which can designate
+        boolean values. This includes values yes and no which are 
+        not designated by xsd:boolean
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="true"/>
+        <xsd:enumeration value="false"/>
+        <xsd:enumeration value="yes"/>
+        <xsd:enumeration value="no"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="iconType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The icon type contains small-icon and large-icon elements
+        that specify the file names for small and large GIF, JPEG,
+        or PNG icon images used to represent the parent element in a
+        GUI tool. 
+        
+        The xml:lang attribute defines the language that the
+        icon file names are provided in. Its value is "en" (English)
+        by default. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="small-icon"
+                   type="jakartaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The small-icon element contains the name of a file
+            containing a small (16 x 16) icon image. The file
+            name is a relative path within the Deployment
+            Component's Deployment File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <small-icon>employee-service-icon16x16.jpg</small-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="large-icon"
+                   type="jakartaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The large-icon element contains the name of a file
+            containing a large
+            (32 x 32) icon image. The file name is a relative 
+            path within the Deployment Component's Deployment
+            File.
+            
+            The image may be in the GIF, JPEG, or PNG format.
+            The icon can be used by tools.
+            
+            Example:
+            
+            <large-icon>employee-service-icon32x32.jpg</large-icon>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute ref="xml:lang"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="injection-targetType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        An injection target specifies a class and a name within
+        that class into which a resource should be injected.
+        
+        The injection target class specifies the fully qualified
+        class name that is the target of the injection.  The
+        Jakarta EE specifications describe which classes can be an
+        injection target.
+        
+        The injection target name specifies the target within
+        the specified class.  The target is first looked for as a
+        JavaBeans property name.  If not found, the target is
+        looked for as a field name.
+        
+        The specified resource will be injected into the target
+        during initialization of the class by either calling the
+        set method for the target property or by setting a value
+        into the named field.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="injection-target-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="injection-target-name"
+                   type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="isolation-levelType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        	The following transaction isolation levels are allowed
+        	(see documentation for the java.sql.Connection interface):
+        TRANSACTION_READ_UNCOMMITTED
+        TRANSACTION_READ_COMMITTED
+        TRANSACTION_REPEATABLE_READ
+        TRANSACTION_SERIALIZABLE
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value="TRANSACTION_READ_UNCOMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_READ_COMMITTED"/>
+      <xsd:enumeration value="TRANSACTION_REPEATABLE_READ"/>
+      <xsd:enumeration value="TRANSACTION_SERIALIZABLE"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-identifierType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The java-identifierType defines a Java identifier.
+        The users of this type should further verify that 
+        the content does not contain Java reserved keywords.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="($|_|\p{L})(\p{L}|\p{Nd}|_|$)*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="java-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a generic type that designates a Java primitive
+        type or a fully qualified name of a Java interface/type,
+        or an array of such types.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="[^\p{Z}]*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jdbc-urlType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The jdbc-urlType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 9.3 of the
+        JDBC Specification where the format is:
+        
+        jdbc:<subprotocol>:<subname>
+        
+        Example:
+        
+        <url>jdbc:mysql://localhost:3307/testdb</url>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="jdbc:(.*):(.*)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-connection-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Messaging Connection Factory.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Messaging Connection Factory.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            messaging connection factory being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging connection factory
+            interface.  Permitted values are jakarta.jms.ConnectionFactory,
+            jakarta.jms.QueueConnectionFactory, or 
+            jakarta.jms.TopicConnectionFactory.  If not specified,
+            jakarta.jms.ConnectionFactory will be used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging connection factory 
+            implementation class.  Ignored if a resource adapter  
+            is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            User name to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password to use for connection authentication.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-id"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Client id to use for connection.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Messaging Connection Factory property.  This may be a vendor-specific
+            property or a less commonly used ConnectionFactory property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transactional"
+                   type="jakartaee:xsdBooleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Set to false if connections should not participate in
+            transactions.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Maximum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="min-pool-size"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Minimum number of connections that should be concurrently
+            allocated for a connection pool.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jms-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Messaging Destination.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Messaging Destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            messaging destination being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="interface-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging destination interface.
+            Permitted values are jakarta.jms.Queue and jakarta.jms.Topic
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="class-name"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Fully-qualified name of the messaging destination implementation
+            class.  Ignored if a resource adapter is used unless the
+            resource adapter defines more than one destination implementation
+            class for the specified interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-adapter"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Resource adapter name.  If not specified, the application
+            server will define the default behavior, which may or may
+            not involve the use of a resource adapter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="destination-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Name of the queue or topic.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Messaging Destination property.  This may be a vendor-specific
+            property or a less commonly used Destination property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jndi-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jndi-nameType type designates a JNDI name in the
+        Deployment Component's environment and is relative to the
+        java:comp/env context.  A JNDI name must be unique within the
+        Deployment Component.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The homeType defines the fully-qualified name of
+        an enterprise bean's home interface. 
+        
+        Example:
+        
+        <home>com.aardvark.payroll.PayrollHome</home>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="lifecycle-callbackType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The lifecycle-callback type specifies a method on a
+        class to be called when a lifecycle event occurs.
+        Note that each class may have only one lifecycle callback
+        method for any given event and that the method may not
+        be overloaded.
+        
+        If the lifefycle-callback-class element is missing then
+        the class defining the callback is assumed to be the
+        component class in scope at the place in the descriptor
+        in which the callback definition appears.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="lifecycle-callback-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"/>
+      <xsd:element name="lifecycle-callback-method"
+                   type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The listenerType indicates the deployment properties for a web
+        application listener bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="listener-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The listener-class element declares a class in the
+            application must be registered as a web
+            application listener bean. The value is the fully
+            qualified classname of the listener class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="localType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The localType defines the fully-qualified name of an
+        enterprise bean's local interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="local-homeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The local-homeType defines the fully-qualified
+        name of an enterprise bean's local home interface.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mail-sessionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Configuration of a Mail Session resource.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Description of this Mail Session resource.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name element specifies the JNDI name of the
+            Mail Session resource being defined.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Storage protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="store-protocol-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider store protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Transport protocol.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="transport-protocol-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Service provider transport protocol implementation class
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="host"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server host name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="user"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server user name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="password"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Password.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Email address to indicate the message sender.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Mail server property.  This may be a vendor-specific
+            property.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="param-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type is a general type that can be used to declare
+        parameter/value lists.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="param-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-name element contains the name of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="param-value"
+                   type="jakartaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The param-value element contains the value of a
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate either a relative
+        path or an absolute path starting with a "/".
+        
+        In elements that specify a pathname to a file within the
+        same Deployment File, relative filenames (i.e., those not
+        starting with "/") are considered relative to the root of
+        the Deployment File's namespace.  Absolute filenames (i.e.,
+        those starting with "/") also specify names in the root of
+        the Deployment File's namespace.  In general, relative names
+        are preferred.  The exception is .war files where absolute
+        names are preferred for consistency with the Servlet API.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-context-ref element contains a declaration
+        of Deployment Component's reference to a persistence context
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence context reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - an optional specification as to whether
+        the persistence context type is Transaction or
+        Extended.  If not specified, Transaction is assumed.
+        - an optional specification as to whether
+        the persistence context synchronization with the current
+        transaction is Synchronized or Unsynchronized. If not
+        specified, Synchronized is assumed.
+        - an optional list of persistence properties
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        </persistence-context-ref>
+        
+        <persistence-context-ref>
+        <persistence-context-ref-name>myPersistenceContext
+        </persistence-context-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        <persistence-context-type>Extended</persistence-context-type>
+        </persistence-context-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-context-ref-name element specifies
+            the name of a persistence context reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Jakarta EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-context-type"
+                   type="jakartaee:persistence-context-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-context-synchronization"
+                   type="jakartaee:persistence-context-synchronizationType"
+                   minOccurs="0"/>
+      <xsd:element name="persistence-property"
+                   type="jakartaee:propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify properties for the container or persistence
+            provider.  Vendor-specific properties may be included in
+            the set of properties.  Properties that are not recognized
+            by a vendor must be ignored.  Entries that make use of the 
+            namespace jakarta.persistence and its subnamespaces must not
+            be used for vendor-specific properties.  The namespace
+            jakarta.persistence is reserved for use by the specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-synchronizationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-synchronizationType specifies 
+        whether a container-managed persistence context is automatically
+        synchronized with the current transaction.
+        
+        The value of the persistence-context-synchronization element 
+        must be one of the following:
+        Synchronized
+        Unsynchronized
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Synchronized"/>
+        <xsd:enumeration value="Unsynchronized"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-context-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-context-typeType specifies the transactional
+        nature of a persistence context reference.  
+        
+        The value of the persistence-context-type element must be
+        one of the following:
+        Transaction
+        Extended
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Transaction"/>
+        <xsd:enumeration value="Extended"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies a name/value pair.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:xsdStringType">
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:xsdStringType">
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-unit-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The persistence-unit-ref element contains a declaration
+        of Deployment Component's reference to a persistence unit
+        associated within a Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the persistence unit reference name
+        - an optional persistence unit name.  If not specified,
+        the default persistence unit is assumed.
+        - optional injection targets
+        
+        Examples:
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        </persistence-unit-ref>
+        
+        <persistence-unit-ref>
+        <persistence-unit-ref-name>myPersistenceUnit
+        </persistence-unit-ref-name>
+        <persistence-unit-name>PersistenceUnit1
+        </persistence-unit-name>
+        </persistence-unit-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The persistence-unit-ref-name element specifies
+            the name of a persistence unit reference; its
+            value is the environment entry name used in
+            Deployment Component code.  The name is a JNDI name
+            relative to the java:comp/env context.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="persistence-unit-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The Application Assembler(or BeanProvider) may use the
+            following syntax to avoid the need to rename persistence
+            units to have unique names within a Jakarta EE application.
+            
+            The Application Assembler specifies the pathname of the
+            root of the persistence.xml file for the referenced
+            persistence unit and appends the name of the persistence
+            unit separated from the pathname by #. The pathname is
+            relative to the referencing application component jar file. 
+            In this manner, multiple persistence units with the same
+            persistence unit name may be uniquely identified when the 
+            Application Assembler cannot change persistence unit names.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceBaseGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="remoteType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The remote element contains the fully-qualified name
+        of the enterprise bean's remote interface.
+        
+        Example:
+        
+        <remote>com.wombat.empl.EmployeeService</remote>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-env-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-env-refType is used to define
+        resource-env-ref elements.  It contains a declaration of a
+        Deployment Component's reference to an administered object
+        associated with a resource in the Deployment Component's
+        environment.  It consists of an optional description, the
+        resource environment reference name, and an optional
+        indication of the resource environment reference type
+        expected by the Deployment Component code.
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The resource environment type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-env-ref>
+        <resource-env-ref-name>jms/StockQueue
+        </resource-env-ref-name>
+        <resource-env-ref-type>jakarta.jms.Queue
+        </resource-env-ref-type>
+        </resource-env-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-name element specifies the name
+            of a resource environment reference; its value is
+            the environment entry name used in
+            the Deployment Component code.  The name is a JNDI 
+            name relative to the java:comp/env context and must 
+            be unique within a Deployment Component.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-env-ref-type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The resource-env-ref-type element specifies the type
+            of a resource environment reference.  It is the
+            fully qualified name of a Java language class or
+            interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="resource-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The resource-refType contains a declaration of a
+        Deployment Component's reference to an external resource. It
+        consists of an optional description, the resource manager
+        connection factory reference name, an optional indication of
+        the resource manager connection factory type expected by the
+        Deployment Component code, an optional type of authentication
+        (Application or Container), and an optional specification of
+        the shareability of connections obtained from the resource
+        (Shareable or Unshareable).
+        
+        It also includes optional elements to define injection of
+        the named resource into fields or JavaBeans properties.
+        
+        The connection factory type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Example:
+        
+        <resource-ref>
+        <res-ref-name>jdbc/EmployeeAppDB</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Container</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+        </resource-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="res-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-ref-name element specifies the name of a
+            resource manager connection factory reference.
+            The name is a JNDI name relative to the
+            java:comp/env context.  
+            The name must be unique within a Deployment File. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The res-type element specifies the type of the data
+            source. The type is specified by the fully qualified
+            Java language class or interface
+            expected to be implemented by the data source.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="res-auth"
+                   type="jakartaee:res-authType"
+                   minOccurs="0"/>
+      <xsd:element name="res-sharing-scope"
+                   type="jakartaee:res-sharing-scopeType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-authType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-authType specifies whether the Deployment Component
+        code signs on programmatically to the resource manager, or
+        whether the Container will sign on to the resource manager
+        on behalf of the Deployment Component. In the latter case,
+        the Container uses information that is supplied by the
+        Deployer.
+        
+        The value must be one of the two following:
+        
+        Application
+        Container
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Application"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="res-sharing-scopeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The res-sharing-scope type specifies whether connections
+        obtained through the given resource manager connection
+        factory reference can be shared. The value, if specified,
+        must be one of the two following:
+        
+        Shareable
+        Unshareable
+        
+        The default value is Shareable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Shareable"/>
+        <xsd:enumeration value="Unshareable"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="run-asType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The run-asType specifies the run-as identity to be
+        used for the execution of a component. It contains an 
+        optional description, and the name of a security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="jakartaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="role-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The role-nameType designates the name of a security role.
+        
+        The name must conform to the lexical rules for a token.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-roleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The security-roleType contains the definition of a security
+        role. The definition consists of an optional description of
+        the security role, and the security role name.
+        
+        Example:
+        
+        <security-role>
+        <description>
+        This role includes all employees who are authorized
+        to access the employee service application.
+        </description>
+        <role-name>employee</role-name>
+        </security-role>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="jakartaee:role-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-role-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-role-refType contains the declaration of a
+        security role reference in a component's or a
+        Deployment Component's code. The declaration consists of an
+        optional description, the security role name used in the
+        code, and an optional link to a security role. If the
+        security role is not specified, the Deployer must choose an
+        appropriate security role.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="jakartaee:role-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The value of the role-name element must be the String used
+            as the parameter to the 
+            EJBContext.isCallerInRole(String roleName) method or the
+            HttpServletRequest.isUserInRole(String role) method.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="role-link"
+                   type="jakartaee:role-nameType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The role-link element is a reference to a defined
+            security role. The role-link element must contain
+            the name of one of the security roles defined in the
+            security-role elements.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdQNameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:QName.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:QName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdBooleanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:boolean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:boolean">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNMTOKENType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:NMTOKEN.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NMTOKEN">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdAnyURIType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:anyURI.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:anyURI">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:integer.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:integer">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdPositiveIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:positiveInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:positiveInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdNonNegativeIntegerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:nonNegativeInteger.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:nonNegativeInteger">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="xsdStringType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type adds an "id" attribute to xsd:string.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="string">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is a special string datatype that is defined by Jakarta EE as
+        a base type for defining collapsed strings. When schemas
+        require trailing/leading space elimination as well as
+        collapsing the existing whitespace, this base type may be
+        used.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:token">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="true-falseType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This simple type designates a boolean with only two
+        permissible values
+        
+        - true
+        - false
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdBooleanType">
+        <xsd:pattern value="(true|false)"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="url-patternType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The url-patternType contains the url pattern of the mapping.
+        It must follow the rules specified in Section 11.2 of the
+        Servlet API Specification. This pattern is assumed to be in
+        URL-decoded form and must not contain CR(#xD) or LF(#xA).
+        If it contains those characters, the container must inform
+        the developer with a descriptive error message.
+        The container must preserve all characters including whitespaces.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destinationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destinationType specifies a message
+        destination. The logical destination described by this
+        element is mapped to a physical destination by the Deployer.
+        
+        The message destination element contains: 
+        
+        - an optional description
+        - an optional display-name
+        - an optional icon
+        - a message destination name which must be unique
+        among message destination names within the same 
+        Deployment File. 
+        - an optional mapped name
+        - an optional lookup name
+        
+        Example: 
+        
+        <message-destination>
+        <message-destination-name>CorporateStocks
+        </message-destination-name>
+        </message-destination>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="message-destination-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-name element specifies a
+            name for a message destination.  This name must be
+            unique among the names of message destinations
+            within the Deployment File.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mapped-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A product specific name that this message destination
+            should be mapped to.  Each message-destination-ref
+            element that references this message destination will
+            define a name in the namespace of the referencing
+            component or in one of the other predefined namespaces. 
+            Many application servers provide a way to map these
+            local names to names of resources known to the
+            application server.  This mapped name is often a global
+            JNDI name, but may be a name of any form.  Each of the
+            local names should be mapped to this same global name.
+            
+            Application servers are not required to support any
+            particular form or type of mapped name, nor the ability
+            to use mapped names.  The mapped name is
+            product-dependent and often installation-dependent.  No
+            use of a mapped name is portable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lookup-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The JNDI name to be looked up to resolve the message destination.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-ref element contains a declaration
+        of Deployment Component's reference to a message destination
+        associated with a resource in Deployment Component's
+        environment. It consists of:
+        
+        - an optional description
+        - the message destination reference name
+        - an optional message destination type
+        - an optional specification as to whether
+        the destination is used for 
+        consuming or producing messages, or both.
+        if not specified, "both" is assumed.
+        - an optional link to the message destination
+        - optional injection targets
+        
+        The message destination type must be supplied unless an
+        injection target is specified, in which case the type
+        of the target is used.  If both are specified, the type
+        must be assignment compatible with the type of the injection
+        target.
+        
+        Examples:
+        
+        <message-destination-ref>
+        <message-destination-ref-name>jms/StockQueue
+        </message-destination-ref-name>
+        <message-destination-type>jakarta.jms.Queue
+        </message-destination-type>
+        <message-destination-usage>Consumes
+        </message-destination-usage>
+        <message-destination-link>CorporateStocks
+        </message-destination-link>
+        </message-destination-ref>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The message-destination-ref-name element specifies
+            the name of a message destination reference; its
+            value is the environment entry name used in
+            Deployment Component code.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-destination-type"
+                   type="jakartaee:message-destination-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-usage"
+                   type="jakartaee:message-destination-usageType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-link"
+                   type="jakartaee:message-destination-linkType"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-usageType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-usageType specifies the use of the
+        message destination indicated by the reference.  The value
+        indicates whether messages are consumed from the message
+        destination, produced for the destination, or both.  The
+        Assembler makes use of this information in linking producers
+        of a destination with its consumers.
+        
+        The value of the message-destination-usage element must be
+        one of the following:
+        Consumes
+        Produces
+        ConsumesProduces
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Consumes"/>
+        <xsd:enumeration value="Produces"/>
+        <xsd:enumeration value="ConsumesProduces"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The message-destination-typeType specifies the type of
+        the destination. The type is specified by the Java interface
+        expected to be implemented by the destination.
+        
+        Example: 
+        
+        <message-destination-type>jakarta.jms.Queue
+        </message-destination-type>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-destination-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-destination-linkType is used to link a message
+        destination reference or message-driven bean to a message
+        destination.
+        
+        The Assembler sets the value to reflect the flow of messages
+        between producers and consumers in the application.
+        
+        The value must be the message-destination-name of a message
+        destination in the same Deployment File or in another
+        Deployment File in the same Jakarta EE application unit.
+        
+        Alternatively, the value may be composed of a path name
+        specifying a Deployment File containing the referenced
+        message destination with the message-destination-name of the
+        destination appended and separated from the path name by
+        "#". The path name is relative to the Deployment File
+        containing Deployment Component that is referencing the
+        message destination.  This allows multiple message
+        destinations with the same name to be uniquely identified.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transaction-supportType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transaction-supportType specifies the level of
+        transaction support provided by the resource adapter. It is
+        used by transaction-support elements.
+        
+        The value must be one of the following:
+        
+        NoTransaction
+        LocalTransaction
+        XATransaction
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="NoTransaction"/>
+        <xsd:enumeration value="LocalTransaction"/>
+        <xsd:enumeration value="XATransaction"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/common/src/main/resources/schema/jakartaee_web_services_2_0.xsd
+++ b/common/src/main/resources/schema/jakartaee_web_services_2_0.xsd
@@ -1,0 +1,551 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      The webservices element is the root element for the web services
+      deployment descriptor.  It specifies the set of web service
+      descriptions that are to be deployed into the Jakarta EE Application
+      Server and the dependencies they have on container resources and
+      services.  The deployment descriptor must be named
+      "META-INF/webservices.xml" in the web services' jar file.
+      
+      Used in: webservices.xml
+      
+      All webservices deployment descriptors must indicate the
+      webservices schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and by indicating the version of the schema by using the version
+      element as shown below:
+      
+      <webservices xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+      	https://jakarta.ee/xml/ns/jakartaee/jakartaee_web_services_2_0.xsd"
+      version="2.0">
+      ...
+      </webservices>
+      
+      The instance documents may indicate the published version of the
+      schema using the xsi:schemaLocation attribute for the Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/jakartaee_web_services_2_0.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="webservices"
+               type="jakartaee:webservicesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webservices element is the root element for the web services
+        deployment descriptor.  It specifies the set of web service
+        descriptions that are to be deployed into the Jakarta EE Application Server
+        and the dependencies they have on container resources and services.
+        
+        Used in: webservices.xml
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:key name="webservice-description-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The webservice-description-name identifies the collection of
+          port-components associated with a WSDL file and Jakarta XML RPC mapping. 
+          The name must be unique within the deployment descriptor.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:webservice-description"/>
+      <xsd:field xpath="jakartaee:webservice-description-name"/>
+    </xsd:key>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The port-component element associates a WSDL port with a web service
+        interface and implementation.  It defines the name of the port as a
+        component, optional description, optional display name, optional iconic
+        representations, WSDL port QName, Service Endpoint Interface, Service
+        Implementation Bean.
+        
+        This element also associates a WSDL service with a Jakarta XML Web Services 
+        Provider implementation.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="display-name"
+                   type="jakartaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="icon"
+                   type="jakartaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="port-component-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The port-component-name element specifies a port component's
+            name.  This name is assigned by the module producer to name
+            the service implementation bean in the module's deployment
+            descriptor. The name must be unique among the port component
+            names defined in the same module.
+            
+            Used in: port-component
+            
+            Example:
+            	      <port-component-name>EmployeeService
+            	      </port-component-name>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-service"
+                   type="jakartaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name space and local name part of the WSDL
+            service QName. This is required to be specified for
+            port components that are Jakarta XML Web Services 
+            	Provider implementations.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-port"
+                   type="jakartaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name space and local name part of the WSDL
+            port QName. This is not required to be specified for port
+            components that are Jakarta XML Web Services Provider
+            	implementations
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism for an
+            endpoint implementation.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mtom-threshold"
+                   type="jakartaee:xsdNonNegativeIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When MTOM is enabled, binary data above this size in bytes
+            will be XOP encoded or sent as attachment. Default value is 0.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="addressing"
+                   type="jakartaee:addressingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            This specifies the WS-Addressing requirements for a Jakarta XML  
+            		web service. It corresponds to jakarta.xml.ws.soap.Addressing
+            annotation or its feature jakarta.xml.ws.soap.AddressingFeature.
+            
+            See the addressingType for more information.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="respect-binding"
+                   type="jakartaee:respect-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Corresponds to the jakarta.xml.ws.RespectBinding annotation
+            or its corresponding jakarta.xml.ws.RespectBindingFeature web
+            service feature. This is used to control whether a Jakarta XML Web 
+            		Services implementation must respect/honor the contents of the
+            wsdl:binding in the WSDL that is associated with the service.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="protocol-binding"
+                   type="jakartaee:protocol-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to specify the protocol binding used by the port-component.
+            If this element is not specified, then the default binding is
+            used (SOAP 1.1 over HTTP)
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-endpoint-interface"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The service-endpoint-interface element contains the
+            fully-qualified name of the port component's Service Endpoint
+            Interface.
+            
+            Used in: port-component
+            
+            Example:
+            	      <remote>com.wombat.empl.EmployeeService</remote>
+            
+            This may not be specified in case there is no Service
+            Enpoint Interface as is the case with directly using an
+            implementation class with the @WebService annotation.
+            
+            When the port component is a Provider implementation
+            this is not specified.
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-impl-bean"
+                   type="jakartaee:service-impl-beanType"/>
+      <xsd:choice>
+        <xsd:element name="handler"
+                     type="jakartaee:handlerType"
+                     minOccurs="0"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with Jakarta XML RPC based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="handler-chains"
+                     type="jakartaee:handler-chainsType"
+                     minOccurs="0"
+                     maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with Jakarta XML Web Services based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-impl-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The service-impl-bean element defines the web service implementation.
+        A service implementation can be an enterprise bean class or Jakarta
+        XML RPC web component.  Existing enterprise bean implementations 
+        are exposed as a web service using an ejb-link.
+        
+        Used in: port-component
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice>
+      <xsd:element name="ejb-link"
+                   type="jakartaee:ejb-linkType"/>
+      <xsd:element name="servlet-link"
+                   type="jakartaee:servlet-linkType"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-linkType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The servlet-link element is used in the service-impl-bean element
+        to specify that a Service Implementation Bean is defined as a
+        Jakarta XML RPC Service Endpoint.
+        
+        The value of the servlet-link element must be the servlet-name of
+        a Jakarta XML RPC Service Endpoint in the same WAR file.
+        
+        Used in: service-impl-bean
+        
+        Example:
+        	  <servlet-link>StockQuoteService</servlet-link>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservice-descriptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webservice-description element defines a WSDL document file
+        and the set of Port components associated with the WSDL ports
+        defined in the WSDL document.  There may be multiple
+        webservice-descriptions defined within a module.
+        
+        All WSDL file ports must have a corresponding port-component element
+        defined.
+        
+        Used in: webservices
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="display-name"
+                   type="jakartaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="icon"
+                   type="jakartaee:iconType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="webservice-description-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The webservice-description-name identifies the collection of
+            port-components associated with a WSDL file and Jakarta XML RPC
+            mapping. The name must be unique within the deployment descriptor.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+                   type="jakartaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The wsdl-file element contains the name of a WSDL file in the
+            module.  The file name is a relative path within the module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+                   type="jakartaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The jaxrpc-mapping-file element contains the name of a file that
+            describes the Jakarta XML RPC mapping between the Java interaces used by
+            the application and the WSDL description in the wsdl-file.  The
+            file name is a relative path within the module.
+            
+            This is not required when JAX-Jakarta Enterprise Web Services based 
+            	runtime is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component"
+                   type="jakartaee:port-componentType"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+        <xsd:key name="port-component_handler-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Defines the name of the handler. The name must be unique
+              within the module.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:handler"/>
+          <xsd:field xpath="jakartaee:handler-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webservicesType">
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="webservice-description"
+                   type="jakartaee:webservice-descriptionType"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+        <xsd:key name="port-component-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              	The port-component-name element specifies a port
+              	component's name.  This name is assigned by the module
+              	producer to name the service implementation bean in the
+              	module's deployment descriptor. The name must be unique
+              	among the port component names defined in the same module.
+              
+              	Used in: port-component
+              
+              	Example:
+              		<port-component-name>EmployeeService
+              		</port-component-name>
+              
+              	
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:port-component"/>
+          <xsd:field xpath="jakartaee:port-component-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="2.0"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 2.0.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/common/src/main/resources/schema/jakartaee_web_services_client_2_0.xsd
+++ b/common/src/main/resources/schema/jakartaee_web_services_client_2_0.xsd
@@ -1,0 +1,714 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="2.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      (C) Copyright International Business Machines Corporation 2002
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="service-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The service-ref element declares a reference to a Web
+        service. It contains optional description, display name and
+        icons, a declaration of the required Service interface,
+        an optional WSDL document location, an optional set
+        of Jakarta XML RPC mappings, an optional QName for the service element,
+        an optional set of Service Endpoint Interfaces to be resolved 
+        by the container to a WSDL port, and an optional set of handlers.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="service-ref-name"
+                   type="jakartaee:jndi-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-name element declares logical name that the
+            components in the module use to look up the Web service. It 
+            is recommended that all service reference names start with 
+            "service/".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-interface"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-interface element declares the fully qualified class
+            name of the Jakarta XML RPC Service interface the client depends on. 
+            In most cases the value will be jakarta.xml.rpc.Service.  A Jakarta XML 
+            RPC generated Service Interface class may also be specified.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-ref-type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-ref-type element declares the type of the service-ref 
+            element that is injected or returned when a JNDI lookup is done.
+            This must be either a fully qualified name of Service class or 
+            the fully qualified name of service endpoint interface class. 
+            This is only used with Jakarta XML Web Services runtime where
+            the corresponding @WebServiceRef annotation can be used to denote both 
+            a Service or a Port.
+            
+            If this is not specified, then the type of service-ref element 
+            that is injected or returned when a JNDI lookup is done is 
+            always a Service interface/class.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="wsdl-file"
+                   type="jakartaee:xsdAnyURIType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The wsdl-file element contains the URI location of a WSDL
+            file. The location is relative to the root of the module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="jaxrpc-mapping-file"
+                   type="jakartaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The jaxrpc-mapping-file element contains the name of a file that
+            describes the Jakarta XML RPC mapping between the Java interaces used by
+            the application and the WSDL description in the wsdl-file.  The 
+            file name is a relative path within the module file.
+            
+            This is not required when Jakarta Enterprise Web Services based 
+            runtime is used.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-qname"
+                   type="jakartaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-qname element declares the specific WSDL service
+            element that is being refered to.  It is not specified if no
+            wsdl-file is declared.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-ref"
+                   type="jakartaee:port-component-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-ref element declares a client dependency
+            on the container for resolving a Service Endpoint Interface
+            to a WSDL port. It optionally associates the Service Endpoint
+            Interface with a particular port-component. This is only used
+            by the container for a Service.getPort(Class) method call.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="handler"
+                     type="jakartaee:handlerType"
+                     minOccurs="0"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	Declares the handler for a port-component. Handlers can
+              	access the init-param name/value pairs using the
+              	HandlerInfo interface. If port-name is not specified, the
+              	handler is assumed to be associated with all ports of the
+              	service.
+              
+              	To be used with Jakarta XML RPC based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="handler-chains"
+                     type="jakartaee:handler-chainsType"
+                     minOccurs="0"
+                     maxOccurs="1">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              	 To be used with Jakarta XML Web Services based runtime only.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:group ref="jakartaee:resourceGroup"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="port-component-refType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The port-component-ref element declares a client dependency
+        on the container for resolving a Service Endpoint Interface
+        to a WSDL port. It optionally associates the Service Endpoint
+        Interface with a particular port-component. This is only used
+        by the container for a Service.getPort(Class) method call.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="service-endpoint-interface"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-endpoint-interface element defines a fully qualified
+            Java class that represents the Service Endpoint Interface of a
+            WSDL port.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enable-mtom"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Used to enable or disable SOAP MTOM/XOP mechanism on the client
+            side for a port-component. 
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="mtom-threshold"
+                   type="jakartaee:xsdNonNegativeIntegerType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When MTOM is enabled, binary data above this size in bytes
+            should be XOP encoded or sent as attachment. Default value is 0.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="addressing"
+                   type="jakartaee:addressingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            This specifies the WS-Addressing requirements for a Jakarta XML 
+            web service. It corresponds to jakarta.xml.ws.soap.Addressing
+            annotation or its feature jakarta.xml.ws.soap.AddressingFeature.
+            
+            See the addressingType for more information.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="respect-binding"
+                   type="jakartaee:respect-bindingType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Corresponds to the jakarta.xml.ws.RespectBinding annotation
+            or its corresponding jakarta.xml.ws.RespectBindingFeature web
+            service feature. This is used to control whether a Jakarta XML Web 
+            Services implementation must respect/honor the contents of the
+            wsdl:binding in the WSDL that is associated with the service.
+            
+            Not to be specified for Jakarta XML RPC runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-component-link"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-component-link element links a port-component-ref
+            to a specific port-component required to be made available
+            by a service reference.
+            
+            The value of a port-component-link must be the
+            port-component-name of a port-component in the same module
+            or another module in the same application unit. The syntax
+            for specification follows the syntax defined for ejb-link
+            in the EJB 2.0 specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chains element defines the handlerchains associated with this
+        service or service endpoint.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="handler-chain"
+                   type="jakartaee:handler-chainType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handler-chainType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The handler-chain element defines the handlerchain. 
+        Handlerchain can be defined such that the handlers in the
+        handlerchain operate,all ports of a service, on a specific
+        port or on a list of protocol-bindings. The choice of elements
+        service-name-pattern, port-name-pattern and protocol-bindings
+        are used to specify whether the handlers in handler-chain are
+        for a service, port or protocol binding. If none of these 
+        choices are specified with the handler-chain element then the
+        handlers specified in the handler-chain will be applied on 
+        everything.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="service-name-pattern"
+                     type="jakartaee:qname-pattern"/>
+        <xsd:element name="port-name-pattern"
+                     type="jakartaee:qname-pattern"/>
+        <xsd:element name="protocol-bindings"
+                     type="jakartaee:protocol-bindingListType"/>
+      </xsd:choice>
+      <xsd:element name="handler"
+                   type="jakartaee:handlerType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="protocol-bindingListType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying a list of
+        protocol-bindingType(s). For e.g.
+        
+        ##SOAP11_HTTP ##SOAP12_HTTP ##XML_HTTP
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:list itemType="jakartaee:protocol-bindingType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type used for specifying the URI for the
+        protocol binding used by the port-component.  For
+        portability one could use one of the following tokens that
+        alias the standard binding types: 
+        
+        ##SOAP11_HTTP
+        ##SOAP11_HTTP_MTOM
+        ##SOAP12_HTTP
+        ##SOAP12_HTTP_MTOM
+        ##XML_HTTP
+        
+        Other specifications could define tokens that start with ##
+        to alias new standard binding URIs that are introduced.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union memberTypes="xsd:anyURI jakartaee:protocol-URIAliasType"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="protocol-URIAliasType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the type that is used for specifying tokens that
+        start with ## which are used to alias existing standard
+        protocol bindings and support aliases for new standard
+        binding URIs that are introduced in future specifications.
+        
+        The following tokens alias the standard protocol binding
+        URIs:
+        
+        ##SOAP11_HTTP = "http://schemas.xmlsoap.org/wsdl/soap/http"
+        ##SOAP11_HTTP_MTOM = 
+        "http://schemas.xmlsoap.org/wsdl/soap/http?mtom=true"
+        ##SOAP12_HTTP = "http://www.w3.org/2003/05/soap/bindings/HTTP/"
+        ##SOAP12_HTTP_MTOM = 
+        "http://www.w3.org/2003/05/soap/bindings/HTTP/?mtom=true"
+        ##XML_HTTP = "http://www.w3.org/2004/08/wsdl/http"
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="##.+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="qname-pattern">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is used to specify the QName pattern in the
+        attribute service-name-pattern and port-name-pattern in
+        the handler-chain element
+        
+        For example, the various forms acceptable here for
+        service-name-pattern attribute in handler-chain element
+        are :
+        
+        Exact Name: service-name-pattern="ns1:EchoService"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports with
+        	 this exact service name. The namespace prefix must
+        	 have been declared in a namespace declaration
+        	 attribute in either the start-tag of the element
+        	 where the prefix is used or in an an ancestor 
+        	 element (i.e. an element in whose content the 
+        	 prefixed markup occurs)
+        	 
+        
+        Pattern : service-name-pattern="ns1:EchoService*"
+        
+        	 In this case, handlers specified in this
+        	 handler-chain element will apply to all ports whose
+        	 Service names are like EchoService1, EchoServiceFoo
+        	 etc. The namespace prefix must have been declared in
+        	 a namespace declaration attribute in either the
+        	 start-tag of the element where the prefix is used or
+        	 in an an ancestor element (i.e. an element in whose 
+        	 content the prefixed markup occurs)
+        
+        Wild Card : service-name-pattern="*"
+        
+        	In this case, handlers specified in this handler-chain
+        	element will apply to ports of all service names.
+        
+        The same can be applied to port-name attribute in
+        handler-chain element.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="\*|([\i-[:]][\c-[:]]*:)?[\i-[:]][\c-[:]]*\*?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This specifies the WS-Addressing requirements for a Jakarta XML web 
+        service. It corresponds to jakarta.xml.ws.soap.Addressing annotation or its
+        feature jakarta.xml.ws.soap.AddressingFeature.
+        
+        If the "enabled" element is "true", WS-Addressing is enabled.
+        It means that the endpoint supports WS-Addressing but does not require
+        its use. The default value for "enabled" is "true".
+        
+        If the WS-Addressing is enabled and the "required" element is "true",
+        it means that the endpoint requires WS-Addressing. The default value
+        for "required" is "false".
+        
+        If WS-Addressing is enabled, the "responses" element determines
+        if an endpoint requires the use of only anonymous responses,
+        or only non-anonymous responses, or all. The value of the "responses"
+        element must be one of the following:
+        
+        ANONYMOUS
+        NON_ANONYMOUS
+        ALL
+        
+        The default value for the "responses" is ALL.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="required"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="responses"
+                   type="jakartaee:addressing-responsesType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="addressing-responsesType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        If WS-Addressing is enabled, this type determines if an endpoint
+        requires the use of only anonymous responses, or only non-anonymous
+        responses, or all.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="ANONYMOUS"/>
+        <xsd:enumeration value="NON_ANONYMOUS"/>
+        <xsd:enumeration value="ALL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="respect-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Corresponds to the jakarta.xml.ws.RespectBinding annotation
+        or its corresponding jakarta.xml.ws.RespectBindingFeature web
+        service feature. This is used to control whether a Jakarta XML 
+        Web Services implementation must respect/honor the contents of the
+        wsdl:binding in the WSDL that is associated with the service.
+        
+        If the "enabled" element is "true", wsdl:binding in the
+        associated WSDL, if any, must be respected/honored.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="enabled"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="handlerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Declares the handler for a port-component, service-ref. Handlers can
+        access the init-param name/value pairs using the HandlerInfo interface.
+        
+        Used in: port-component, service-ref
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="handler-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the name of the handler. The name must be unique within the
+            module.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="handler-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a fully qualified class name for the handler implementation.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+                   type="jakartaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Not to be specified for Jakarta XML Web Services runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-header"
+                   type="jakartaee:xsdQNameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the QName of a SOAP header that will be processed by the
+            handler.
+            
+            Not to be specified for Jakarta XML Web Services runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="soap-role"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The soap-role element contains a SOAP actor definition that the
+            Handler will play as a role.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="port-name"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The port-name element defines the WSDL port-name that a
+            handler should be associated with. If port-name is not
+            specified, the handler is assumed to be associated with
+            all ports of the service.
+            
+            Not to be specified for Jakarta XML Web Services runtime
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:group name="service-refGroup">
+    <xsd:sequence>
+      <xsd:element name="service-ref"
+                   type="jakartaee:service-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:key name="service-ref_handler-name-key">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Defines the name of the handler. The name must be unique
+              within the module.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:handler"/>
+          <xsd:field xpath="jakartaee:handler-name"/>
+        </xsd:key>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:group>
+
+</xsd:schema>

--- a/ear/src/main/resources/schema/application_9.xsd
+++ b/ear/src/main/resources/schema/application_9.xsd
@@ -1,0 +1,390 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="9">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application 9 deployment
+      descriptor.  The deployment descriptor must be named
+      "META-INF/application.xml" in the application's ear file.
+      All application deployment descriptors must indicate
+      the application schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <application xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/application_9.xsd"
+      version="9">
+      ...
+      </application>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/application_9.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="application"
+               type="jakartaee:applicationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The application element is the root element of a Jakarta EE
+        application deployment descriptor.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="context-root-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The context-root element content must be unique
+          in the ear. 
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:module/jakartaee:web"/>
+      <xsd:field xpath="jakartaee:context-root"/>
+    </xsd:unique>
+    <xsd:unique name="security-role-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The security-role-name element content
+          must be unique in the ear.  
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:security-role"/>
+      <xsd:field xpath="jakartaee:role-name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="applicationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The applicationType defines the structure of the
+        application. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="application-name"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="initialize-in-order"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            If initialize-in-order is true, modules must be initialized
+            in the order they're listed in this deployment descriptor,
+            with the exception of application client modules, which can
+            be initialized in any order.
+            If initialize-in-order is not set or set to false, the order
+            of initialization is unspecified and may be product-dependent.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="module"
+                   type="jakartaee:moduleType"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The application deployment descriptor must have one
+            module element for each Jakarta EE module in the
+            application package. A module element is defined 
+            by moduleType definition. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="security-role"
+                   type="jakartaee:security-roleType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="library-directory"
+                   type="jakartaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The library-directory element specifies the pathname
+            of a directory within the application package, relative
+            to the top level of the application package.  All files
+            named "*.jar" in this directory must be made available
+            in the class path of all components included in this
+            application package.  If this element isn't specified,
+            the directory named "lib" is searched.  An empty element
+            may be used to disable searching.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="env-entry"
+                   type="jakartaee:env-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-ref"
+                   type="jakartaee:ejb-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-local-ref"
+                   type="jakartaee:ejb-local-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:service-refGroup"/>
+      <xsd:element name="resource-ref"
+                   type="jakartaee:resource-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="resource-env-ref"
+                   type="jakartaee:resource-env-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination-ref"
+                   type="jakartaee:message-destination-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-context-ref"
+                   type="jakartaee:persistence-context-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="persistence-unit-ref"
+                   type="jakartaee:persistence-unit-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination"
+                   type="jakartaee:message-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="data-source"
+                   type="jakartaee:data-sourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-connection-factory"
+                   type="jakartaee:jms-connection-factoryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jms-destination"
+                   type="jakartaee:jms-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="mail-session"
+                   type="jakartaee:mail-sessionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="connection-factory"
+                   type="jakartaee:connection-factory-resourceType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="administered-object"
+                   type="jakartaee:administered-objectType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="9"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The required value for the version is 9.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="moduleType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The moduleType defines a single Jakarta EE module and contains a
+        connector, ejb, java, or web element, which indicates the
+        module type and contains a path to the module file, and an
+        optional alt-dd element, which specifies an optional URI to
+        the post-assembly version of the deployment descriptor.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice>
+        <xsd:element name="connector"
+                     type="jakartaee:pathType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The connector element specifies the URI of a
+              resource adapter archive file, relative to the
+              top level of the application package.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="ejb"
+                     type="jakartaee:pathType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb element specifies the URI of an ejb-jar,
+              relative to the top level of the application
+              package.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="java"
+                     type="jakartaee:pathType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The java element specifies the URI of a java
+              application client module, relative to the top
+              level of the application package.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="web"
+                     type="jakartaee:webType"/>
+      </xsd:choice>
+      <xsd:element name="alt-dd"
+                   type="jakartaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The alt-dd element specifies an optional URI to the
+            post-assembly version of the deployment descriptor
+            file for a particular Jakarta EE module.  The URI must
+            specify the full pathname of the deployment
+            descriptor file relative to the application's root
+            directory. If alt-dd is not specified, the deployer
+            must read the deployment descriptor from the default
+            location and file name required by the respective
+            component specification.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="webType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The webType defines the web-uri and context-root of
+        a web application module.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="web-uri"
+                   type="jakartaee:pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The web-uri element specifies the URI of a web
+            application file, relative to the top level of the
+            application package.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="context-root"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The context-root element specifies the context root
+            of a web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/ejb/src/main/resources/schema/ejb-jar_4_0.xsd
+++ b/ejb/src/main/resources/schema/ejb-jar_4_0.xsd
@@ -1,0 +1,3351 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="4.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the Enterprise Beans 4.0 deployment descriptor.
+      
+      All Enterprise Beans deployment descriptors must indicate
+      the schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and by indicating the version of the schema by
+      using the version element as shown below:
+      
+      <ejb-jar xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+      	  https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd"
+      version="4.0">
+      ...
+      </ejb-jar>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for the
+      Jakarta EE namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="ejb-jar"
+               type="jakartaee:ejb-jarType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This is the root of the ejb-jar deployment descriptor.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:key name="ejb-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-name element contains the name of an enterprise
+          bean. The name must be unique within the ejb-jar file or
+          .war file.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:enterprise-beans/*"/>
+      <xsd:field xpath="jakartaee:ejb-name"/>
+    </xsd:key>
+    <xsd:keyref name="ejb-name-references"
+                refer="jakartaee:ejb-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          relationship-role-source must be to a specific ejb-name
+          defined within the scope of enterprise-beans element. 
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath=".//jakartaee:ejb-relationship-role/jakartaee:relationship-role-source"/>
+      <xsd:field xpath="jakartaee:ejb-name"/>
+    </xsd:keyref>
+    <xsd:key name="role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          A role-name-key is specified to allow the references
+          from the security-role-refs.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:assembly-descriptor/jakartaee:security-role"/>
+      <xsd:field xpath="jakartaee:role-name"/>
+    </xsd:key>
+    <xsd:keyref name="role-name-references"
+                refer="jakartaee:role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          security-role-ref to a specified role-name.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:enterprise-beans/*/jakartaee:security-role-ref"/>
+      <xsd:field xpath="jakartaee:role-link"/>
+    </xsd:keyref>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="access-timeoutType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The access-timeoutType represents the maximum amount of
+        time (in a given time unit) that the container should wait for
+        a concurrency lock before throwing a timeout exception to the
+        client.
+        
+        A timeout value of 0 means concurrent access is not permitted.
+        
+        A timeout value of -1 means wait indefinitely to acquire a lock.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="timeout"
+                   type="jakartaee:xsdIntegerType"/>
+      <xsd:element name="unit"
+                   type="jakartaee:time-unit-typeType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="async-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The async-methodType element specifies that a session
+        bean method has asynchronous invocation semantics.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method-name"
+                   type="jakartaee:string"/>
+      <xsd:element name="method-params"
+                   type="jakartaee:method-paramsType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="activation-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The activation-configType defines information about the
+        expected configuration properties of the message-driven bean
+        in its operational environment. This may include information
+        about message acknowledgement, message selector, expected
+        destination type, destination or connection factory lookup
+        string, subscription name, etc.
+        
+        The configuration information is expressed in terms of
+        name/value configuration properties.
+        
+        The properties that are recognized for a particular
+        message-driven bean are determined by the messaging type.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="activation-config-property"
+                   type="jakartaee:activation-config-propertyType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="activation-config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The activation-config-propertyType contains a name/value
+        configuration property pair for a message-driven bean.
+        
+        The properties that are recognized for a particular
+        message-driven bean are determined by the messaging type.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="activation-config-property-name"
+                   type="jakartaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The activation-config-property-name element contains
+            the name for an activation configuration property of
+            a message-driven bean.
+            
+            For Jakarta Messaging message-driven beans, the following property
+            names are recognized: acknowledgeMode,
+            messageSelector, destinationType, subscriptionDurability,
+            destinationLookup, connectionFactoryLookup, subscriptionName,
+            and clientId.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="activation-config-property-value"
+                   type="jakartaee:xsdStringType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The activation-config-property-value element
+            contains the value for an activation configuration
+            property of a message-driven bean.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="around-invokeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The around-invoke type specifies a method on a
+        class to be called during the around invoke portion of an 
+        ejb invocation.  Note that each class may have only one
+        around invoke method and that the method may not be
+        overloaded.
+        
+        If the class element is missing then
+        the class defining the callback is assumed to be the
+        interceptor class or component class in scope at the
+        location in the descriptor in which the around invoke
+        definition appears.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"/>
+      <xsd:element name="method-name"
+                   type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="around-timeoutType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The around-timeout type specifies a method on a
+        class to be called during the around-timeout portion of
+        a timer timeout callback.  Note that each class may have 
+        only one around-timeout method and that the method may not 
+        be overloaded.
+        
+        If the class element is missing then
+        the class defining the callback is assumed to be the
+        interceptor class or component class in scope at the
+        location in the descriptor in which the around-timeout
+        definition appears.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"/>
+      <xsd:element name="method-name"
+                   type="jakartaee:java-identifierType"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="assembly-descriptorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The assembly-descriptorType defines
+        application-assembly information.
+        
+        The application-assembly information consists of the
+        following parts: the definition of security roles, the
+        definition of method permissions, the definition of
+        transaction attributes for enterprise beans with
+        container-managed transaction demarcation, the definition
+        of interceptor bindings, a list of
+        methods to be excluded from being invoked, and a list of
+        exception types that should be treated as application exceptions.
+        
+        All the parts are optional in the sense that they are
+        omitted if the lists represented by them are empty.
+        
+        Providing an assembly-descriptor in the deployment
+        descriptor is optional for the ejb-jar file or .war file producer.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="security-role"
+                   type="jakartaee:security-roleType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="method-permission"
+                   type="jakartaee:method-permissionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="container-transaction"
+                   type="jakartaee:container-transactionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="interceptor-binding"
+                   type="jakartaee:interceptor-bindingType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="message-destination"
+                   type="jakartaee:message-destinationType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="exclude-list"
+                   type="jakartaee:exclude-listType"
+                   minOccurs="0"/>
+      <xsd:element name="application-exception"
+                   type="jakartaee:application-exceptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cmp-fieldType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The cmp-fieldType describes a container-managed field. The
+        cmp-fieldType contains an optional description of the field,
+        and the name of the field.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="field-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The field-name element specifies the name of a
+            container managed field.
+            
+            The name of the cmp-field of an entity bean with
+            cmp-version 2.x must begin with a lowercase
+            letter. This field is accessed by methods whose
+            names consists of the name of the field specified by
+            field-name in which the first letter is uppercased,
+            prefixed by "get" or "set".
+            
+            The name of the cmp-field of an entity bean with
+            cmp-version 1.x must denote a public field of the
+            enterprise bean class or one of its superclasses.
+            
+            Support for entity beans is optional as of Enterprise Beans 3.2.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cmp-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The cmp-versionType specifies the version of an entity bean
+        with container-managed persistence. It is used by
+        cmp-version elements.
+        
+        The value must be one of the two following:
+        
+        1.x
+        2.x
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="1.x"/>
+        <xsd:enumeration value="2.x"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cmr-fieldType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The cmr-fieldType describes the Bean Provider's view of
+        a relationship. It consists of an optional description, and
+        the name and the class type of a field in the source of a
+        role of a relationship. The cmr-field-name element
+        corresponds to the name used for the get and set accessor
+        methods for the relationship. The cmr-field-type element is
+        used only for collection-valued cmr-fields. It specifies the
+        type of the collection that is used.
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="cmr-field-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The cmr-field-name element specifies the name of a
+            logical relationship field in the entity bean
+            class. The name of the cmr-field must begin with a
+            lowercase letter. This field is accessed by methods
+            whose names consist of the name of the field
+            specified by cmr-field-name in which the first
+            letter is uppercased, prefixed by "get" or "set".
+            
+            Support for entity beans is optional as of Enterprise Beans 3.2.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="cmr-field-type"
+                   type="jakartaee:cmr-field-typeType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cmr-field-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The cmr-field-type element specifies the class of a
+        collection-valued logical relationship field in the entity
+        bean class. The value of an element using cmr-field-typeType
+        must be either: java.util.Collection or java.util.Set.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="java.util.Collection"/>
+        <xsd:enumeration value="java.util.Set"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="concurrency-management-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The concurrency-management-typeType specifies the way concurrency
+        is managed for a singleton or stateful session bean.  
+        
+        The concurrency management type must be one of the following:
+        
+        Bean
+        Container
+        
+        Bean managed concurrency can only be specified for a singleton bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Bean"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="concurrent-lock-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The concurrent-lock-typeType specifies how the container must
+        manage concurrent access to a method of a Singleton bean 
+        with container-managed concurrency.
+        
+        The container managed concurrency lock type must be one 
+        of the following :
+        
+        Read
+        Write
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Read"/>
+        <xsd:enumeration value="Write"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="concurrent-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The concurrent-methodType specifies information about a method
+        of a bean with container managed concurrency.
+        
+        The optional lock element specifies the kind of concurrency 
+        lock asssociated with the method.
+        
+        The optional access-timeout element specifies the amount of
+        time (in a given time unit) the container should wait for a
+        concurrency lock before throwing an exception to the client.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method"
+                   type="jakartaee:named-methodType"/>
+      <xsd:element name="lock"
+                   type="jakartaee:concurrent-lock-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="access-timeout"
+                   type="jakartaee:access-timeoutType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="container-transactionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The container-transactionType specifies how the container
+        must manage transaction scopes for the enterprise bean's
+        method invocations. It defines an optional description, a
+        list of method elements, and a transaction attribute. The
+        transaction attribute is to be applied to all the specified
+        methods.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="method"
+                   type="jakartaee:methodType"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="trans-attribute"
+                   type="jakartaee:trans-attributeType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="depends-onType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The depends-onType is used to express initialization 
+        ordering dependencies between Singleton components.
+        The depends-onType specifies the names of one or more
+        Singleton beans in the same application as the referring
+        Singleton, each of which must be initialized before
+        the referring bean.  
+        
+        Each dependent bean is expressed using ejb-link syntax.
+        The order in which dependent beans are initialized at 
+        runtime is not guaranteed to match the order in which
+        they are listed.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="ejb-name"
+                   type="jakartaee:ejb-linkType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-classType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-classType contains the fully-qualified name of the
+        enterprise bean's class. It is used by ejb-class elements. 
+        
+        Example:
+        
+        <ejb-class>com.wombat.empl.EmployeeServiceBean</ejb-class>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-jarType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-jarType defines the root element of the Enterprise Beans
+        deployment descriptor. It contains
+        
+        - an optional description of the ejb-jar file
+        - an optional display name
+        - an optional icon that contains a small and a large
+        icon file name
+        - an optional module name. Only applicable to
+        stand-alone ejb-jars or ejb-jars packaged in an ear.
+        Ignored if specified for an ejb-jar.xml within a .war file.
+        In that case, standard .war file module-name rules apply.
+        - structural information about all included
+        enterprise beans that is not specified through
+        annotations
+        - structural information about interceptor classes
+        - a descriptor for container managed relationships, 
+        if any. 
+        - an optional application-assembly descriptor
+        - an optional name of an ejb-client-jar file for the 
+        ejb-jar.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="module-name"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="enterprise-beans"
+                   type="jakartaee:enterprise-beansType"
+                   minOccurs="0"/>
+      <xsd:element name="interceptors"
+                   type="jakartaee:interceptorsType"
+                   minOccurs="0"/>
+      <xsd:element name="relationships"
+                   type="jakartaee:relationshipsType"
+                   minOccurs="0">
+        <xsd:unique name="relationship-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-relation-name contains the name of a
+              relation. The name must be unique within
+              relationships.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:ejb-relation"/>
+          <xsd:field xpath="jakartaee:ejb-relation-name"/>
+        </xsd:unique>
+      </xsd:element>
+      <xsd:element name="assembly-descriptor"
+                   type="jakartaee:assembly-descriptorType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Providing an assembly-descriptor in the deployment
+            descriptor is optional for the ejb-jar file or .war file
+            producer.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="ejb-client-jar"
+                   type="jakartaee:pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            The optional ejb-client-jar element specifies a JAR
+            file that contains the class files necessary for a
+            client program to access the
+            enterprise beans in the ejb-jar file.
+            
+            Example:
+            
+            	  <ejb-client-jar>employee_service_client.jar
+            	  </ejb-client-jar>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="4.0"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The version specifies the version of the
+          Enterprise Beans specification that the instance document must 
+          comply with. This information enables deployment tools
+          to validate a particular Enterprise Beans Deployment
+          Descriptor with respect to a specific version of the Enterprise Beans
+          schema. 
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          deployment descriptor and other related deployment
+          descriptors for this module (e.g., web service
+          descriptors) are complete, or whether the class
+          files available to this module and packaged with
+          this application should be examined for annotations
+          that specify deployment information.
+          
+          If metadata-complete is set to "true", the deployment
+          tool must ignore any annotations that specify deployment
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the deployment tool must examine the class
+          files of the application for annotations, as
+          specified by the specifications.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-nameType specifies an enterprise bean's name. It is
+        used by ejb-name elements. This name is assigned by the
+        file producer to name the enterprise bean in the
+        ejb-jar file or .war file's deployment descriptor. The name must be
+        unique among the names of the enterprise beans in the same
+        ejb-jar file or .war file.
+        
+        There is no architected relationship between the used
+        ejb-name in the deployment descriptor and the JNDI name that
+        the Deployer will assign to the enterprise bean's home.
+        
+        The name for an entity bean must conform to the lexical
+        rules for an NMTOKEN.
+        
+        Example:
+        
+        <ejb-name>EmployeeService</ejb-name>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdNMTOKENType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-relationType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The ejb-relationType describes a relationship between two
+        entity beans with container-managed persistence.  It is used
+        by ejb-relation elements. It contains a description; an
+        optional ejb-relation-name element; and exactly two
+        relationship role declarations, defined by the
+        ejb-relationship-role elements. The name of the
+        relationship, if specified, is unique within the ejb-jar
+        file.
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-relation-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The ejb-relation-name element provides a unique name
+            within the ejb-jar file for a relationship.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="ejb-relationship-role"
+                   type="jakartaee:ejb-relationship-roleType"
+                   minOccurs="2"
+                   maxOccurs="2"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ejb-relationship-roleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The ejb-relationship-roleType describes a role within a
+        relationship. There are two roles in each relationship.
+        
+        The ejb-relationship-roleType contains an optional
+        description; an optional name for the relationship role; a
+        specification of the multiplicity of the role; an optional
+        specification of cascade-delete functionality for the role;
+        the role source; and a declaration of the cmr-field, if any,
+        by means of which the other side of the relationship is
+        accessed from the perspective of the role source.
+        
+        The multiplicity and role-source element are mandatory.
+        
+        The relationship-role-source element designates an entity
+        bean by means of an ejb-name element. For bidirectional
+        relationships, both roles of a relationship must declare a
+        relationship-role-source element that specifies a cmr-field
+        in terms of which the relationship is accessed. The lack of
+        a cmr-field element in an ejb-relationship-role specifies
+        that the relationship is unidirectional in navigability and
+        the entity bean that participates in the relationship is
+        "not aware" of the relationship.
+        
+        Example:
+        
+        <ejb-relation>
+        <ejb-relation-name>Product-LineItem</ejb-relation-name>
+        <ejb-relationship-role>
+        	  <ejb-relationship-role-name>product-has-lineitems
+        	  </ejb-relationship-role-name>
+        	  <multiplicity>One</multiplicity>
+        	  <relationship-role-source>
+        	  <ejb-name>ProductEJB</ejb-name>
+        	  </relationship-role-source>
+        </ejb-relationship-role>
+        </ejb-relation>
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-relationship-role-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The ejb-relationship-role-name element defines a
+            name for a role that is unique within an
+            ejb-relation. Different relationships can use the
+            same name for a role.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="multiplicity"
+                   type="jakartaee:multiplicityType"/>
+      <xsd:element name="cascade-delete"
+                   type="jakartaee:emptyType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The cascade-delete element specifies that, within a
+            particular relationship, the lifetime of one or more
+            entity beans is dependent upon the lifetime of
+            another entity bean. The cascade-delete element can
+            only be specified for an ejb-relationship-role
+            element contained in an ejb-relation element in
+            which the other ejb-relationship-role
+            element specifies a multiplicity of One.
+            
+            Support for entity beans is optional as of Enterprise Beans 3.2.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="relationship-role-source"
+                   type="jakartaee:relationship-role-sourceType"/>
+      <xsd:element name="cmr-field"
+                   type="jakartaee:cmr-fieldType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="enterprise-beansType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The enterprise-beansType declares one or more enterprise
+        beans. Each bean can be a session, entity or message-driven
+        bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice maxOccurs="unbounded">
+      <xsd:element name="session"
+                   type="jakartaee:session-beanType">
+        <xsd:unique name="session-ejb-local-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-ref-name element contains the name of
+              an enterprise bean reference. The enterprise bean reference is an entry in
+              the component's environment and is relative to the
+              java:comp/env context.  The name must be unique within
+              the component.
+              
+              It is recommended that name be prefixed with "ejb/".
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:ejb-local-ref"/>
+          <xsd:field xpath="jakartaee:ejb-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="session-ejb-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-ref-name element contains the name of an enterprise bean
+              reference. The enterprise bean reference is an entry in the
+              component's environment and is relative to the
+              java:comp/env context. The name must be unique
+              within the component.
+              
+              It is recommended that name is prefixed with "ejb/".
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:ejb-ref"/>
+          <xsd:field xpath="jakartaee:ejb-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="session-resource-env-ref-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The resource-env-ref-name element specifies the name
+              of a resource environment reference; its value is
+              the environment entry name used in the component
+              code. The name is a JNDI name relative to the
+              java:comp/env context and must be unique within an
+              component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:resource-env-ref"/>
+          <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="session-message-destination-ref-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The message-destination-ref-name element specifies the name
+              of a message destination reference; its value is
+              the message destination reference name used in the component
+              code. The name is a JNDI name relative to the
+              java:comp/env context and must be unique within an
+              component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:message-destination-ref"/>
+          <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="session-res-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The res-ref-name element specifies the name of a
+              resource manager connection factory reference.  The name
+              is a JNDI name relative to the java:comp/env context.
+              The name must be unique within an component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:resource-ref"/>
+          <xsd:field xpath="jakartaee:res-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="session-env-entry-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The env-entry-name element contains the name of a
+              component's environment entry.  The name is a JNDI
+              name relative to the java:comp/env context.  The
+              name must be unique within an component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:env-entry"/>
+          <xsd:field xpath="jakartaee:env-entry-name"/>
+        </xsd:unique>
+      </xsd:element>
+      <xsd:element name="entity"
+                   type="jakartaee:entity-beanType">
+        <xsd:unique name="entity-ejb-local-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-ref-name element contains the name of
+              an enterprise bean reference. The enterprise bean reference is an entry in
+              the component's environment and is relative to the
+              java:comp/env context.  The name must be unique within
+              the component.
+              
+              It is recommended that name be prefixed with "ejb/".
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:ejb-local-ref"/>
+          <xsd:field xpath="jakartaee:ejb-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="entity-ejb-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-ref-name element contains the name of an enterprise bean
+              reference. The enterprise bean reference is an entry in the
+              component's environment and is relative to the
+              java:comp/env context. The name must be unique
+              within the component.
+              
+              It is recommended that name is prefixed with "ejb/".
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:ejb-ref"/>
+          <xsd:field xpath="jakartaee:ejb-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="entity-resource-env-ref-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The resource-env-ref-name element specifies the name
+              of a resource environment reference; its value is
+              the environment entry name used in the component
+              code. The name is a JNDI name relative to the
+              java:comp/env context and must be unique within an
+              component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:resource-env-ref"/>
+          <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="entity-message-destination-ref-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The message-destination-ref-name element specifies the name
+              of a message destination reference; its value is
+              the message destination reference name used in the component
+              code. The name is a JNDI name relative to the
+              java:comp/env context and must be unique within an
+              component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:message-destination-ref"/>
+          <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="entity-res-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The res-ref-name element specifies the name of a
+              resource manager connection factory reference.  The name
+              is a JNDI name relative to the java:comp/env context.
+              The name must be unique within an component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:resource-ref"/>
+          <xsd:field xpath="jakartaee:res-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="entity-env-entry-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The env-entry-name element contains the name of a
+              component's environment entry.  The name is a JNDI
+              name relative to the java:comp/env context.  The
+              name must be unique within an component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:env-entry"/>
+          <xsd:field xpath="jakartaee:env-entry-name"/>
+        </xsd:unique>
+      </xsd:element>
+      <xsd:element name="message-driven"
+                   type="jakartaee:message-driven-beanType">
+        <xsd:unique name="messaged-ejb-local-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-ref-name element contains the name of
+              an enterprise bean reference. The enterprise bean reference is an entry in
+              the component's environment and is relative to the
+              java:comp/env context.  The name must be unique within
+              the component.
+              
+              It is recommended that name be prefixed with "ejb/".
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:ejb-local-ref"/>
+          <xsd:field xpath="jakartaee:ejb-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="messaged-ejb-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-ref-name element contains the name of an enterprise bean
+              reference. The enterprise bean reference is an entry in the
+              component's environment and is relative to the
+              java:comp/env context. The name must be unique
+              within the component.
+              
+              It is recommended that name is prefixed with "ejb/".
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:ejb-ref"/>
+          <xsd:field xpath="jakartaee:ejb-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="messaged-resource-env-ref-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The resource-env-ref-name element specifies the name
+              of a resource environment reference; its value is
+              the environment entry name used in the component
+              code. The name is a JNDI name relative to the
+              java:comp/env context and must be unique within an
+              component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:resource-env-ref"/>
+          <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="messaged-message-destination-ref-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The message-destination-ref-name element specifies the name
+              of a message destination reference; its value is
+              the message destination reference name used in the component
+              code. The name is a JNDI name relative to the
+              java:comp/env context and must be unique within an
+              component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:message-destination-ref"/>
+          <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="messaged-res-ref-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The res-ref-name element specifies the name of a
+              resource manager connection factory reference.  The name
+              is a JNDI name relative to the java:comp/env context.
+              The name must be unique within an component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:resource-ref"/>
+          <xsd:field xpath="jakartaee:res-ref-name"/>
+        </xsd:unique>
+        <xsd:unique name="messaged-env-entry-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The env-entry-name element contains the name of a
+              component's environment entry.  The name is a JNDI
+              name relative to the java:comp/env context.  The
+              name must be unique within an component.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath="jakartaee:env-entry"/>
+          <xsd:field xpath="jakartaee:env-entry-name"/>
+        </xsd:unique>
+      </xsd:element>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="entity-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+        The entity-beanType declares an entity bean. The declaration
+        consists of:
+        
+        - an optional description
+        - an optional display name
+        - an optional icon element that contains a small and a large 
+        icon file name
+        - a unique name assigned to the enterprise bean
+        in the deployment descriptor
+        - an optional mapped-name element that can be used to provide
+        vendor-specific deployment information such as the physical
+        jndi-name of the entity bean's remote home interface. This 
+        element is not required to be supported by all implementations.
+        Any use of this element is non-portable.
+        - the names of the entity bean's remote home 
+        and remote interfaces, if any
+        - the names of the entity bean's local home and local
+        interfaces, if any
+        - the entity bean's implementation class
+        - the optional entity bean's persistence management type. If 
+        this element is not specified it is defaulted to Container.
+        - the entity bean's primary key class name
+        - an indication of the entity bean's reentrancy
+        - an optional specification of the 
+        entity bean's cmp-version
+        - an optional specification of the entity bean's
+        abstract schema name
+        - an optional list of container-managed fields
+        - an optional specification of the primary key 
+        field
+        - an optional declaration of the bean's environment 
+        entries
+        - an optional declaration of the bean's enterprise bean 
+        references
+        - an optional declaration of the bean's local enterprise bean 
+        references
+        - an optional declaration of the bean's web 
+        service references
+        - an optional declaration of the security role 
+        references
+        - an optional declaration of the security identity
+        to be used for the execution of the bean's methods
+        - an optional declaration of the bean's 
+        resource manager connection factory references
+        - an optional declaration of the bean's
+        resource environment references
+        - an optional declaration of the bean's message 
+        destination references
+        - an optional set of query declarations
+        for finder and select methods for an entity
+        bean with cmp-version 2.x.
+        
+        The optional abstract-schema-name element must be specified
+        for an entity bean with container-managed persistence and
+        cmp-version 2.x.
+        
+        The optional primkey-field may be present in the descriptor
+        if the entity's persistence-type is Container.
+        
+        The optional cmp-version element may be present in the
+        descriptor if the entity's persistence-type is Container. If
+        the persistence-type is Container and the cmp-version
+        element is not specified, its value defaults to 2.x.
+        
+        The optional home and remote elements must be specified if
+        the entity bean cmp-version is 1.x.
+        
+        The optional home and remote elements must be specified if
+        the entity bean has a remote home and remote interface.
+        
+        The optional local-home and local elements must be specified
+        if the entity bean has a local home and local interface.
+        
+        Either both the local-home and the local elements or both
+        the home and the remote elements must be specified.
+        
+        The optional query elements must be present if the
+        persistence-type is Container and the cmp-version is 2.x and
+        query methods other than findByPrimaryKey have been defined
+        for the entity bean.
+        
+        The other elements that are optional are "optional" in the
+        sense that they are omitted if the lists represented by them
+        are empty.
+        
+        At least one cmp-field element must be present in the
+        descriptor if the entity's persistence-type is Container and
+        the cmp-version is 1.x, and none must not be present if the
+        entity's persistence-type is Bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="ejb-name"
+                   type="jakartaee:ejb-nameType"/>
+      <xsd:element name="mapped-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0"/>
+      <xsd:element name="home"
+                   type="jakartaee:homeType"
+                   minOccurs="0"/>
+      <xsd:element name="remote"
+                   type="jakartaee:remoteType"
+                   minOccurs="0"/>
+      <xsd:element name="local-home"
+                   type="jakartaee:local-homeType"
+                   minOccurs="0"/>
+      <xsd:element name="local"
+                   type="jakartaee:localType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-class"
+                   type="jakartaee:ejb-classType"/>
+      <xsd:element name="persistence-type"
+                   type="jakartaee:persistence-typeType"/>
+      <xsd:element name="prim-key-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The prim-key-class element contains the
+            fully-qualified name of an
+            entity bean's primary key class.
+            
+            If the definition of the primary key class is
+            deferred to deployment time, the prim-key-class 
+            element should specify java.lang.Object.
+            
+            Support for entity beans is optional as of Enterprise Beans 3.2.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="reentrant"
+                   type="jakartaee:true-falseType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The reentrant element specifies whether an entity
+            bean is reentrant or not.
+            
+            The reentrant element must be one of the two
+            following: true or false
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="cmp-version"
+                   type="jakartaee:cmp-versionType"
+                   minOccurs="0"/>
+      <xsd:element name="abstract-schema-name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The abstract-schema-name element specifies the name
+            of the abstract schema type of an entity bean with 
+            cmp-version 2.x. It is used in Enterprise Beans QL queries. 
+            
+            For example, the abstract-schema-name for an entity 
+            bean whose local interface is 
+            com.acme.commerce.Order might be Order. 
+            
+            Support for entity beans is optional as of Enterprise Beans 3.2.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="cmp-field"
+                   type="jakartaee:cmp-fieldType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="primkey-field"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The primkey-field element is used to specify the
+            name of the primary key field for an entity with
+            container-managed persistence.
+            
+            The primkey-field must be one of the fields declared
+            in the cmp-field element, and the type of the field
+            must be the same as the primary key type.
+            
+            The primkey-field element is not used if the primary
+            key maps to multiple container-managed fields
+            (i.e. the key is a compound key). In this case, the
+            fields of the primary key class must be public, and
+            their names must correspond to the field names of
+            the entity bean class that comprise the key.
+            
+            Support for entity beans is optional as of Enterprise Beans 3.2.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+      <xsd:element name="security-role-ref"
+                   type="jakartaee:security-role-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="security-identity"
+                   type="jakartaee:security-identityType"
+                   minOccurs="0"/>
+      <xsd:element name="query"
+                   type="jakartaee:queryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="exclude-listType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The exclude-listType specifies one or more methods which
+        the Assembler marks to be uncallable.
+        
+        If the method permission relation contains methods that are
+        in the exclude list, the Deployer should consider those
+        methods to be uncallable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="method"
+                   type="jakartaee:methodType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="application-exceptionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The application-exceptionType declares an application
+        exception. The declaration consists of:
+        
+        - the exception class. When the container receives
+        an exception of this type, it is required to 
+        forward this exception as an applcation exception 
+        to the client regardless of whether it is a checked
+        or unchecked exception.
+        - an optional rollback element. If this element is 
+        set to true, the container must rollback the current 
+        transaction before forwarding the exception to the
+        client.  If not specified, it defaults to false.
+        - an optional inherited element. If this element is 
+        set to true, subclasses of the exception class type
+        are also automatically considered application 
+        exceptions (unless overriden at a lower level).
+        If set to false, only the exception class type is
+        considered an application-exception, not its
+        exception subclasses. If not specified, this
+        value defaults to true.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="exception-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="rollback"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="inherited"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="interceptorsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The interceptorsType element declares one or more interceptor
+        classes used by components within this ejb-jar file or .war file.  The declaration
+        consists of :
+        
+        - An optional description.
+        - One or more interceptor elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="interceptor"
+                   type="jakartaee:interceptorType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="interceptorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The interceptorType element declares information about a single
+        interceptor class.  It consists of :
+        
+        - An optional description.
+        - The fully-qualified name of the interceptor class.
+        - An optional list of around invoke methods declared on the
+        interceptor class and/or its super-classes.
+        - An optional list of around timeout methods declared on the
+        interceptor class and/or its super-classes.
+        - An optional list environment dependencies for the interceptor
+        class and/or its super-classes.
+        - An optional list of post-activate methods declared on the
+        interceptor class and/or its super-classes.
+        - An optional list of pre-passivate methods declared on the
+        interceptor class and/or its super-classes.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="interceptor-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="around-invoke"
+                   type="jakartaee:around-invokeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="around-timeout"
+                   type="jakartaee:around-timeoutType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="around-construct"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+      <xsd:element name="post-activate"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-passivate"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="interceptor-bindingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The interceptor-bindingType element describes the binding of
+        interceptor classes to beans within the ejb-jar file or .war file.
+        It consists of :
+        
+        - An optional description.
+        - The name of an ejb within the module or the wildcard value "*",
+        which is used to define interceptors that are bound to all
+        beans in the ejb-jar file or .war file.
+        - A list of interceptor classes that are bound to the contents of
+        the ejb-name element or a specification of the total ordering
+        over the interceptors defined for the given level and above.
+        - An optional exclude-default-interceptors element.  If set to true,
+        specifies that default interceptors are not to be applied to 
+        a bean-class and/or business method.
+        - An optional exclude-class-interceptors element.  If set to true,
+        specifies that class interceptors are not to be applied to 
+        a business method.
+        - An optional set of method elements for describing the name/params
+        of a method-level interceptor.
+        
+        Interceptors bound to all classes using the wildcard syntax
+        "*" are default interceptors for the components in the ejb-jar file or .war file. 
+        In addition, interceptors may be bound at the level of the bean
+        class (class-level interceptors) or business methods (method-level
+        interceptors ).
+        
+        The binding of interceptors to classes is additive.  If interceptors
+        are bound at the class-level and/or default-level as well as the
+        method-level, both class-level and/or default-level as well as
+        method-level will apply. 
+        
+        The method-name element may be used to bind a constructor-level 
+        interceptor using the unqualified name of the bean class as the value; 
+        the optional method-params elements identify the constructor if a bean 
+        class has a constructor annotated with the Inject annotation in addition 
+        to a no-arg constructor.
+        
+        There are four possible styles of the interceptor element syntax :
+        
+        1.
+        <interceptor-binding>
+        <ejb-name>*</ejb-name>
+        <interceptor-class>INTERCEPTOR</interceptor-class>
+        </interceptor-binding>
+        
+        Specifying the ejb-name as the wildcard value "*" designates
+        default interceptors (interceptors that apply to all session and
+        message-driven beans contained in the ejb-jar file or .war file).
+        
+        2. 
+        <interceptor-binding>
+        <ejb-name>EJBNAME</ejb-name>
+        <interceptor-class>INTERCEPTOR</interceptor-class>
+        </interceptor-binding>
+        
+        This style is used to refer to interceptors associated with the
+        specified enterprise bean(class-level interceptors).
+        
+        3. 
+        <interceptor-binding>
+        <ejb-name>EJBNAME</ejb-name>
+        <interceptor-class>INTERCEPTOR</interceptor-class>
+        <method>
+        <method-name>METHOD</method-name>
+        </method>
+        </interceptor-binding>
+        
+        This style is used to associate a method-level interceptor with 
+        the specified enterprise bean.  If there are multiple methods
+        with the same overloaded name, the element of this style refers
+        to all the methods with the overloaded name.  Method-level
+        interceptors can only be associated with business methods of the
+        bean class.   Note that the wildcard value "*" cannot be used
+        to specify method-level interceptors.
+        
+        4. 
+        <interceptor-binding>
+        <ejb-name>EJBNAME</ejb-name>
+        <interceptor-class>INTERCEPTOR</interceptor-class>
+        <method>
+        <method-name>METHOD</method-name>
+        <method-params>
+        <method-param>PARAM-1</method-param>
+        <method-param>PARAM-2</method-param>
+        ...
+        <method-param>PARAM-N</method-param>
+        </method-params>
+        </method>
+        </interceptor-binding>
+        
+        This style is used to associate a method-level interceptor with 
+        the specified method of the specified enterprise bean.  This 
+        style is used to refer to a single method within a set of methods
+        with an overloaded name.  The values PARAM-1 through PARAM-N
+        are the fully-qualified Java types of the method's input parameters
+        (if the method has no input arguments, the method-params element
+        contains no method-param elements). Arrays are specified by the
+        array element's type, followed by one or more pair of square 
+        brackets (e.g. int[][]).
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-name"
+                   type="jakartaee:string"/>
+      <xsd:choice>
+        <xsd:element name="interceptor-class"
+                     type="jakartaee:fully-qualified-classType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+        <xsd:element name="interceptor-order"
+                     type="jakartaee:interceptor-orderType"
+                     minOccurs="1"/>
+      </xsd:choice>
+      <xsd:element name="exclude-default-interceptors"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="exclude-class-interceptors"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="method"
+                   type="jakartaee:named-methodType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="interceptor-orderType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The interceptor-orderType element describes a total ordering
+        of interceptor classes.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="interceptor-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="named-methodType">
+    <xsd:sequence>
+      <xsd:element name="method-name"
+                   type="jakartaee:string"/>
+      <xsd:element name="method-params"
+                   type="jakartaee:method-paramsType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="init-methodType">
+    <xsd:sequence>
+      <xsd:element name="create-method"
+                   type="jakartaee:named-methodType"/>
+      <xsd:element name="bean-method"
+                   type="jakartaee:named-methodType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="remove-methodType">
+    <xsd:sequence>
+      <xsd:element name="bean-method"
+                   type="jakartaee:named-methodType"/>
+      <xsd:element name="retain-if-exception"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="message-driven-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The message-driven element declares a message-driven
+        bean. The declaration consists of:
+        
+        - an optional description
+        - an optional display name
+        - an optional icon element that contains a small and a large 
+        icon file name. 
+        - a name assigned to the enterprise bean in
+        the deployment descriptor
+        - an optional mapped-name element that can be used to provide
+        vendor-specific deployment information such as the physical
+        jndi-name of destination from which this message-driven bean
+        should consume.  This element is not required to be supported 
+        by all implementations.  Any use of this element is non-portable.
+        - the message-driven bean's implementation class
+        - an optional declaration of the bean's messaging 
+        type 
+        - an optional declaration of the bean's timeout method for
+        handling programmatically created timers
+        - an optional declaration of timers to be automatically created at
+        deployment time
+        - the optional message-driven bean's transaction management 
+        type. If it is not defined, it is defaulted to Container.
+        - an optional declaration of the bean's 
+        message-destination-type
+        - an optional declaration of the bean's 
+        message-destination-link
+        - an optional declaration of the message-driven bean's
+        activation configuration properties
+        - an optional list of the message-driven bean class and/or
+        superclass around-invoke methods.
+        - an optional list of the message-driven bean class and/or
+        superclass around-timeout methods.
+        - an optional declaration of the bean's environment
+        entries
+        - an optional declaration of the bean's enterprise bean references
+        - an optional declaration of the bean's local enterprise bean 
+        	  references
+        - an optional declaration of the bean's web service
+        references
+        - an optional declaration of the security role 
+        references
+        - an optional declaration of the security
+        identity to be used for the execution of the bean's
+        methods
+        - an optional declaration of the bean's 
+        resource manager connection factory 
+        references
+        - an optional declaration of the bean's resource
+        environment references.
+        - an optional declaration of the bean's message 
+        destination references
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="ejb-name"
+                   type="jakartaee:ejb-nameType"/>
+      <xsd:element name="mapped-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-class"
+                   type="jakartaee:ejb-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The ejb-class element specifies the fully qualified name
+            of the bean class for this ejb.  It is required unless
+            there is a component-defining annotation for the same
+            ejb-name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="messaging-type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The messaging-type element specifies the message
+            listener interface of the message-driven bean. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="timeout-method"
+                   type="jakartaee:named-methodType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The timeout-method element specifies the method that
+            will receive callbacks for programmatically
+            created timers.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="timer"
+                   type="jakartaee:timerType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="transaction-type"
+                   type="jakartaee:transaction-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-type"
+                   type="jakartaee:message-destination-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="message-destination-link"
+                   type="jakartaee:message-destination-linkType"
+                   minOccurs="0"/>
+      <xsd:element name="activation-config"
+                   type="jakartaee:activation-configType"
+                   minOccurs="0"/>
+      <xsd:element name="around-invoke"
+                   type="jakartaee:around-invokeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="around-timeout"
+                   type="jakartaee:around-timeoutType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+      <xsd:element name="security-role-ref"
+                   type="jakartaee:security-role-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+      </xsd:element>
+      <xsd:element name="security-identity"
+                   type="jakartaee:security-identityType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The methodType is used to denote a method of an enterprise
+        bean.  The method may be any of the following or a set of
+        any of the following methods may be designated:
+        business interface method
+        home interface method
+        component interface method
+        web service endpoint interface method
+        no-interface view method
+        singleton session bean lifecycle callback method
+        stateful session bean lifecycle callback method (see 
+        limitations)
+        timeout callback method
+        message-driven bean message listener method
+        
+        The ejb-name element must be the name of one of the enterprise 
+        beans declared in the deployment descriptor.
+        The optional method-intf element allows distinguishing between a
+        method with the same signature that is multiply defined
+        across any of the above.
+        The method-name element specifies the method name.
+        The optional method-params elements identify a single method 
+        among multiple methods with an overloaded method name.
+        
+        There are three possible styles of using methodType element
+        within a method element:
+        
+        1.
+        <method>
+        <ejb-name>EJBNAME</ejb-name>
+        <method-name>*</method-name>
+        </method>
+        
+        This style is used to refer to all of the following methods 
+        of the specified enterprise bean:
+        business interface methods
+        home interface methods
+        component interface methods
+        web service endpoint interface methods
+        no-interface view methods
+        singleton session bean lifecycle callback methods
+        timeout callback methods
+        message-driven bean message listener method
+        
+        This style may also be used in combination with the 
+        method-intf element that contains LifecycleCallback as 
+        the value to specify transaction attributes of a stateful 
+        session bean PostConstruct, PreDestroy, PrePassivate, 
+        and PostActivate lifecycle callback methods or to override 
+        transaction attributes of a singleton session bean 
+        PostConstruct and PreDestroy lifecycle callback methods.
+        
+        2.
+        <method>
+        <ejb-name>EJBNAME</ejb-name>
+        <method-name>METHOD</method-name>
+        </method>
+        
+        This style is used to refer to the specified method of
+        the specified enterprise bean. If there are multiple
+        methods with the same overloaded name, the element of
+        this style refers to all the methods with the overloaded
+        name.
+        
+        This style may be used to refer to stateful session bean
+        PostConstruct, PreDestroy, PrePassivate, and PostActivate 
+        lifecycle callback methods to specify their transaction
+        attributes if any of the following is true:
+        there is only one method with this name in the specified 
+        enterprise bean
+        all overloaded methods with this name in the specified 
+        enterprise bean are lifecycle callback methods
+        method-intf element is specified and it contains 
+        LifecycleCallback as the value 
+        
+        3.
+        <method>
+        <ejb-name>EJBNAME</ejb-name>
+        <method-name>METHOD</method-name>
+        <method-params>
+        	  <method-param>PARAM-1</method-param>
+        	  <method-param>PARAM-2</method-param>
+        	  ...
+        	  <method-param>PARAM-n</method-param>
+        </method-params>
+        </method>
+        
+        This style is used to refer to a single method within a
+        set of methods with an overloaded name. PARAM-1 through
+        PARAM-n are the fully-qualified Java types of the
+        method's input parameters (if the method has no input
+        arguments, the method-params element contains no
+        method-param elements). Arrays are specified by the
+        array element's type, followed by one or more pair of
+        square brackets (e.g. int[][]). 
+        If a method with the same name and signature is defined 
+        on more than one interface of an enterprise bean, this 
+        style refers to all those methods. 
+        
+        Examples:
+        
+        Style 1: The following method element refers to all of the
+        following methods of the EmployeeService bean:
+        no interface view methods
+        business interface methods   
+        home interface methods   
+        component business interface methods   
+        singleton session bean lifecycle callback methods, if any
+        timeout callback methods
+        web service endpoint interface methods
+        message-driven bean message listener methods (if the bean
+        a message-driven bean)
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-name>*</method-name>
+        </method>
+        
+        Style 2: The following method element refers to all the
+        create methods of the EmployeeService bean's home
+        interface(s).
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-name>create</method-name>
+        </method>
+        
+        Style 3: The following method element refers to the
+        create(String firstName, String LastName) method of the
+        EmployeeService bean's home interface(s).
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-name>create</method-name>
+        <method-params>
+        	  <method-param>java.lang.String</method-param>
+        	  <method-param>java.lang.String</method-param>
+        </method-params>
+        </method>
+        
+        The following example illustrates a Style 3 element with
+        more complex parameter types. The method 
+        foobar(char s, int i, int[] iar, mypackage.MyClass mycl, 
+        mypackage.MyClass[][] myclaar) would be specified as:
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-name>foobar</method-name>
+        <method-params>
+        	  <method-param>char</method-param>
+        	  <method-param>int</method-param>
+        	  <method-param>int[]</method-param>
+        	  <method-param>mypackage.MyClass</method-param>
+        	  <method-param>mypackage.MyClass[][]</method-param>
+        </method-params>
+        </method>
+        
+        The optional method-intf element can be used when it becomes
+        necessary to differentiate between a method that is defined
+        multiple times with the same name and signature across any
+        of the following methods of an enterprise bean:
+        business interface methods
+        home interface methods
+        component interface methods
+        web service endpoint methods
+        no-interface view methods
+        singleton or stateful session bean lifecycle callback methods
+        timeout callback methods
+        message-driven bean message listener methods
+        
+        However, if the same method is a method of both the local 
+        business interface, and the local component interface, 
+        the same attribute applies to the method for both interfaces.
+        Likewise, if the same method is a method of both the remote 
+        business interface and the remote component interface, the same
+        attribute applies to the method for both interfaces.
+        
+        For example, the method element
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-intf>Remote</method-intf>
+        <method-name>create</method-name>
+        <method-params>
+        	  <method-param>java.lang.String</method-param>
+        	  <method-param>java.lang.String</method-param>
+        </method-params>
+        </method>
+        
+        can be used to differentiate the create(String, String)
+        method defined in the remote interface from the
+        create(String, String) method defined in the remote home
+        interface, which would be defined as
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-intf>Home</method-intf>
+        <method-name>create</method-name>
+        <method-params>
+        	  <method-param>java.lang.String</method-param>
+        	  <method-param>java.lang.String</method-param>
+        </method-params>
+        </method>
+        
+        and the create method that is defined in the local home
+        interface which would be defined as
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-intf>LocalHome</method-intf>
+        <method-name>create</method-name>
+        <method-params>
+        	  <method-param>java.lang.String</method-param>
+        	  <method-param>java.lang.String</method-param>
+        </method-params>
+        </method>
+        
+        The method-intf element can be used with all three Styles
+        of the method element usage. For example, the following
+        method element example could be used to refer to all the
+        methods of the EmployeeService bean's remote home interface
+        and the remote business interface.
+        
+        <method>
+        <ejb-name>EmployeeService</ejb-name>
+        <method-intf>Home</method-intf>
+        <method-name>*</method-name>
+        </method>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-name"
+                   type="jakartaee:ejb-nameType"/>
+      <xsd:element name="method-intf"
+                   type="jakartaee:method-intfType"
+                   minOccurs="0">
+      </xsd:element>
+      <xsd:element name="method-name"
+                   type="jakartaee:method-nameType"/>
+      <xsd:element name="method-params"
+                   type="jakartaee:method-paramsType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="method-intfType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The method-intf element allows a method element to
+        differentiate between the methods with the same name and
+        signature that are multiply defined across the home and
+        component interfaces (e.g, in both an enterprise bean's
+        remote and local interfaces or in both an enterprise bean's
+        home and remote interfaces, etc.); the component and web
+        service endpoint interfaces, and so on. 
+        
+        Local applies to the local component interface, local business 
+        interfaces, and the no-interface view. 
+        
+        Remote applies to both remote component interface and the remote 
+        business interfaces.  
+        
+        ServiceEndpoint refers to methods exposed through a web service
+        endpoint.
+        
+        Timer refers to the bean's timeout callback methods.
+        
+        MessageEndpoint refers to the methods of a message-driven bean's
+        message-listener interface.
+        
+        LifecycleCallback refers to the PostConstruct and PreDestroy
+        lifecycle callback methods of a singleton session bean and
+        to the PostConstruct, PreDestroy, PrePassivate, and PostActivate
+        lifecycle callback methods of a stateful session bean.
+        
+        The method-intf element must be one of the following:
+        
+        Home
+        Remote
+        LocalHome
+        Local
+        ServiceEndpoint
+        Timer
+        MessageEndpoint
+        LifecycleCallback
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Home"/>
+        <xsd:enumeration value="Remote"/>
+        <xsd:enumeration value="LocalHome"/>
+        <xsd:enumeration value="Local"/>
+        <xsd:enumeration value="ServiceEndpoint"/>
+        <xsd:enumeration value="Timer"/>
+        <xsd:enumeration value="MessageEndpoint"/>
+        <xsd:enumeration value="LifecycleCallback"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="method-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The method-nameType contains a name of an enterprise
+        bean method or the asterisk (*) character. The asterisk is
+        used when the element denotes all the methods of an
+        enterprise bean's client view interfaces.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="method-paramsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The method-paramsType defines a list of the
+        fully-qualified Java type names of the method parameters.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method-param"
+                   type="jakartaee:java-typeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The method-param element contains a primitive
+            or a fully-qualified Java type name of a method
+            parameter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="method-permissionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The method-permissionType specifies that one or more
+        security roles are allowed to invoke one or more enterprise
+        bean methods. The method-permissionType consists of an
+        optional description, a list of security role names or an
+        indicator to state that the method is unchecked for
+        authorization, and a list of method elements.
+        
+        Except as noted below the security roles used in the
+        method-permissionType must be defined in the security-role
+        elements of the deployment descriptor, and the methods
+        must be methods defined in the enterprise bean's no-interface
+        view, business, home, component and/or web service endpoint
+        interfaces. 
+        
+        If the role name "**" is included in the list of allowed 
+        roles, and the application has not defined in its deployment 
+        descriptor an application security role with this name, 
+        then the list of allowed roles includes every and any 
+        authenticated user.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:choice>
+        <xsd:element name="role-name"
+                     type="jakartaee:role-nameType"
+                     maxOccurs="unbounded"/>
+        <xsd:element name="unchecked"
+                     type="jakartaee:emptyType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The unchecked element specifies that a method is
+              not checked for authorization by the container
+              prior to invocation of the method.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="method"
+                   type="jakartaee:methodType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="multiplicityType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The multiplicityType describes the multiplicity of the
+        role that participates in a relation.
+        
+        The value must be one of the two following:
+        
+        One
+        Many
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="One"/>
+        <xsd:enumeration value="Many"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="persistence-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The persistence-typeType specifies an entity bean's persistence
+        management type.
+        
+        The persistence-type element must be one of the two following:
+        
+        Bean
+        Container
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Bean"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="queryType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The queryType defines a finder or select
+        query. It contains
+        - an optional description of the query
+        - the specification of the finder or select
+        method it is used by
+        	- an optional specification of the result type 
+        	  mapping, if the query is for a select method 
+        	  and entity objects are returned.
+        	- the Enterprise Beans QL query string that defines the query.
+        
+        Queries that are expressible in Enterprise Beans QL must use the ejb-ql
+        element to specify the query. If a query is not expressible
+        in Enterprise Beans QL, the description element should be used to
+        describe the semantics of the query and the ejb-ql element
+        should be empty.
+        
+        The result-type-mapping is an optional element. It can only
+        be present if the query-method specifies a select method
+        that returns entity objects.  The default value for the
+        result-type-mapping element is "Local".
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"/>
+      <xsd:element name="query-method"
+                   type="jakartaee:query-methodType"/>
+      <xsd:element name="result-type-mapping"
+                   type="jakartaee:result-type-mappingType"
+                   minOccurs="0"/>
+      <xsd:element name="ejb-ql"
+                   type="jakartaee:xsdStringType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="query-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        The query-method specifies the method for a finder or select
+        query.
+        
+        The method-name element specifies the name of a finder or select
+        method in the entity bean's implementation class.
+        
+        Each method-param must be defined for a query-method using the
+        method-params element.
+        
+        It is used by the query-method element. 
+        
+        Example:
+        
+        <query>
+        <description>Method finds large orders</description>
+        <query-method>
+        	  <method-name>findLargeOrders</method-name>
+        	  <method-params></method-params>
+        </query-method>
+        <ejb-ql>
+        	SELECT OBJECT(o) FROM Order o
+        	  WHERE o.amount &gt; 1000
+        </ejb-ql>
+        </query>
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method-name"
+                   type="jakartaee:method-nameType"/>
+      <xsd:element name="method-params"
+                   type="jakartaee:method-paramsType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="relationship-role-sourceType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The relationship-role-sourceType designates the source of a
+        role that participates in a relationship. A
+        relationship-role-sourceType is used by
+        relationship-role-source elements to uniquely identify an
+        entity bean.
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-name"
+                   type="jakartaee:ejb-nameType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="relationshipsType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The relationshipsType describes the relationships in
+        which entity beans with container-managed persistence
+        participate. The relationshipsType contains an optional
+        description; and a list of ejb-relation elements, which
+        specify the container managed relationships.
+        
+        Support for entity beans is optional as of Enterprise Beans 3.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="ejb-relation"
+                   type="jakartaee:ejb-relationType"
+                   maxOccurs="unbounded">
+        <xsd:unique name="role-name-uniqueness">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The ejb-relationship-role-name contains the name of a
+              relationship role. The name must be unique within 
+              a relationship, but can be reused in different
+              relationships.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+          <xsd:selector xpath=".//jakartaee:ejb-relationship-role-name"/>
+          <xsd:field xpath="."/>
+        </xsd:unique>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="result-type-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The result-type-mappingType is used in the query element to
+        specify whether an abstract schema type returned by a query
+        for a select method is to be mapped to an EJBLocalObject or
+        EJBObject type.
+        
+        The value must be one of the following:
+        
+        Local
+        Remote
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Local"/>
+        <xsd:enumeration value="Remote"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-identityType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-identityType specifies whether the caller's
+        security identity is to be used for the execution of the
+        methods of the enterprise bean or whether a specific run-as
+        identity is to be used. It contains an optional description
+        and a specification of the security identity to be used.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:choice>
+        <xsd:element name="use-caller-identity"
+                     type="jakartaee:emptyType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The use-caller-identity element specifies that
+              the caller's security identity be used as the
+              security identity for the execution of the
+              enterprise bean's methods.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="run-as"
+                     type="jakartaee:run-asType"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="session-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The session-beanType declares an session bean. The
+        declaration consists of:
+        
+        - an optional description
+        - an optional display name
+        - an optional icon element that contains a small and a large 
+        icon file name
+        - a name assigned to the enterprise bean
+        in the deployment description
+        - an optional mapped-name element that can be used to provide
+        vendor-specific deployment information such as the physical
+        jndi-name of the session bean's remote home/business interface. 
+        This element is not required to be supported by all 
+        implementations. Any use of this element is non-portable.
+        - the names of all the remote or local business interfaces, 
+        if any
+        - the names of the session bean's remote home and
+        remote interfaces, if any
+        - the names of the session bean's local home and
+        local interfaces, if any
+        - an optional declaration that this bean exposes a
+        no-interface view
+        - the name of the session bean's web service endpoint
+        interface, if any
+        - the session bean's implementation class
+        - the session bean's state management type
+        - an optional declaration of a stateful session bean's timeout value
+        - an optional declaration of the session bean's timeout method for
+        handling programmatically created timers
+        - an optional declaration of timers to be automatically created at
+        deployment time
+        - an optional declaration that a Singleton bean has eager
+        initialization
+        - an optional declaration of a Singleton/Stateful bean's concurrency 
+        management type
+        - an optional declaration of the method locking metadata
+        for a Singleton with container managed concurrency
+        - an optional declaration of the other Singleton beans in the
+        application that must be initialized before this bean
+        - an optional declaration of the session bean's asynchronous 
+        methods
+        - the optional session bean's transaction management type. 
+        If it is not present, it is defaulted to Container.
+        - an optional declaration of a stateful session bean's 
+        afterBegin, beforeCompletion, and/or afterCompletion methods
+        - an optional list of the session bean class and/or
+        superclass around-invoke methods.
+        - an optional list of the session bean class and/or
+        superclass around-timeout methods.
+        - an optional declaration of the bean's 
+        environment entries
+        - an optional declaration of the bean's enterprise bean references
+        - an optional declaration of the bean's local enterprise bean
+        references
+        - an optional declaration of the bean's web 
+        service references
+        - an optional declaration of the security role 
+        references
+        - an optional declaration of the security identity 
+        to be used for the execution of the bean's methods
+        - an optional declaration of the bean's resource 
+        manager connection factory references
+        - an optional declaration of the bean's resource 
+        environment references.
+        - an optional declaration of the bean's message 
+        destination references
+        - an optional specification as to whether the stateful 
+        session bean is passivation capable or not. If not 
+        specified, the bean is assumed to be passivation capable
+        
+        The elements that are optional are "optional" in the sense
+        that they are omitted when if lists represented by them are
+        empty.
+        
+        The service-endpoint element may only be specified if the
+        bean is a stateless session bean.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="ejb-name"
+                   type="jakartaee:ejb-nameType"/>
+      <xsd:element name="mapped-name"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0"/>
+      <xsd:element name="home"
+                   type="jakartaee:homeType"
+                   minOccurs="0"/>
+      <xsd:element name="remote"
+                   type="jakartaee:remoteType"
+                   minOccurs="0"/>
+      <xsd:element name="local-home"
+                   type="jakartaee:local-homeType"
+                   minOccurs="0"/>
+      <xsd:element name="local"
+                   type="jakartaee:localType"
+                   minOccurs="0"/>
+      <xsd:element name="business-local"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="business-remote"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="local-bean"
+                   type="jakartaee:emptyType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The local-bean element declares that this
+            session bean exposes a no-interface Local client view.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="service-endpoint"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The service-endpoint element contains the
+            fully-qualified name of the enterprise bean's web
+            service endpoint interface. The service-endpoint
+            element may only be specified for a stateless
+            session bean. The specified interface must be a
+            valid Jakarta XML RPC service endpoint interface.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="ejb-class"
+                   type="jakartaee:ejb-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The ejb-class element specifies the fully qualified name
+            of the bean class for this ejb.  It is required unless
+            there is a component-defining annotation for the same
+            ejb-name.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="session-type"
+                   type="jakartaee:session-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="stateful-timeout"
+                   type="jakartaee:stateful-timeoutType"
+                   minOccurs="0"/>
+      <xsd:element name="timeout-method"
+                   type="jakartaee:named-methodType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The timeout-method element specifies the method that
+            will receive callbacks for programmatically
+            created timers.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="timer"
+                   type="jakartaee:timerType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="init-on-startup"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The init-on-startup element specifies that a Singleton
+            bean has eager initialization.
+            This element can only be specified for singleton session
+            beans.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="concurrency-management-type"
+                   type="jakartaee:concurrency-management-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="concurrent-method"
+                   type="jakartaee:concurrent-methodType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="depends-on"
+                   type="jakartaee:depends-onType"
+                   minOccurs="0"/>
+      <xsd:element name="init-method"
+                   type="jakartaee:init-methodType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The init-method element specifies the mappings for
+            Enterprise Beans 2.x style create methods for an Enterprise Beans 3.x bean.
+            This element can only be specified for stateful 
+            session beans. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="remove-method"
+                   type="jakartaee:remove-methodType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The remove-method element specifies the mappings for
+            Enterprise Beans 2.x style remove methods for an Enterprise Beans 3.x bean.
+            This element can only be specified for stateful 
+            session beans. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="async-method"
+                   type="jakartaee:async-methodType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="transaction-type"
+                   type="jakartaee:transaction-typeType"
+                   minOccurs="0"/>
+      <xsd:element name="after-begin-method"
+                   type="jakartaee:named-methodType"
+                   minOccurs="0"/>
+      <xsd:element name="before-completion-method"
+                   type="jakartaee:named-methodType"
+                   minOccurs="0"/>
+      <xsd:element name="after-completion-method"
+                   type="jakartaee:named-methodType"
+                   minOccurs="0"/>
+      <xsd:element name="around-invoke"
+                   type="jakartaee:around-invokeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="around-timeout"
+                   type="jakartaee:around-timeoutType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+      <xsd:element name="post-activate"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="pre-passivate"
+                   type="jakartaee:lifecycle-callbackType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="security-role-ref"
+                   type="jakartaee:security-role-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="security-identity"
+                   type="jakartaee:security-identityType"
+                   minOccurs="0"/>
+      <xsd:element name="passivation-capable"
+                   type="xsd:boolean"
+                   default="true"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The passivation-capable element specifies whether the 
+            stateful session bean is passivation capable or not. 
+            If not specified, the bean is assumed to be passivation 
+            capable.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="session-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The session-typeType describes whether the session bean is a
+        singleton, stateful or stateless session. It is used by
+        session-type elements.
+        
+        The value must be one of the three following:
+        
+        Singleton
+        Stateful
+        Stateless
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Singleton"/>
+        <xsd:enumeration value="Stateful"/>
+        <xsd:enumeration value="Stateless"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="stateful-timeoutType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The stateful-timeoutType represents the amount of time
+        a stateful session bean can be idle(not receive any client
+        invocations) before it is eligible for removal by the container.
+        
+        A timeout value of 0 means the bean is immediately eligible for removal.
+        
+        A timeout value of -1 means the bean will never be removed due to timeout.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="timeout"
+                   type="jakartaee:xsdIntegerType"/>
+      <xsd:element name="unit"
+                   type="jakartaee:time-unit-typeType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="time-unit-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The time-unit-typeType represents a time duration at a given
+        unit of granularity.  
+        
+        The time unit type must be one of the following :
+        
+        Days
+        Hours
+        Minutes
+        Seconds
+        Milliseconds
+        Microseconds
+        Nanoseconds
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Days"/>
+        <xsd:enumeration value="Hours"/>
+        <xsd:enumeration value="Minutes"/>
+        <xsd:enumeration value="Seconds"/>
+        <xsd:enumeration value="Milliseconds"/>
+        <xsd:enumeration value="Microseconds"/>
+        <xsd:enumeration value="Nanoseconds"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="timer-scheduleType">
+    <xsd:sequence>
+      <xsd:element name="second"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:element name="minute"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:element name="hour"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:element name="day-of-month"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:element name="month"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:element name="day-of-week"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:element name="year"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="timerType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The timerType specifies an enterprise bean timer.  Each
+        timer is automatically created by the container upon
+        deployment.  Timer callbacks occur based on the 
+        schedule attributes.  All callbacks are made to the
+        timeout-method associated with the timer.  
+        
+        A timer can have an optional start and/or end date. If
+        a start date is specified, it takes precedence over the
+        associated timer schedule such that any matching
+        expirations prior to the start time will not occur.
+        Likewise, no matching expirations will occur after any
+        end date.   Start/End dates are specified using the
+        XML Schema dateTime type, which follows the ISO-8601
+        standard for date(and optional time-within-the-day) 
+        representation.
+        
+        An optional flag can be used to control whether
+        this timer has persistent(true) delivery semantics or
+        non-persistent(false) delivery semantics.  If not specified,
+        the value defaults to persistent(true).
+        
+        A time zone can optionally be associated with a timer.
+        If specified, the timer's schedule is evaluated in the context
+        of that time zone, regardless of the default time zone in which
+        the container is executing.   Time zones are specified as an
+        ID string.  The set of required time zone IDs is defined by
+        the Zone Name(TZ) column of the public domain zoneinfo database.
+        
+        An optional info string can be assigned to the timer and 
+        retrieved at runtime through the Timer.getInfo() method.
+        
+        The timerType can only be specified on stateless session
+        beans, singleton session beans, and message-driven beans.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="schedule"
+                   type="jakartaee:timer-scheduleType"/>
+      <xsd:element name="start"
+                   type="xsd:dateTime"
+                   minOccurs="0"/>
+      <xsd:element name="end"
+                   type="xsd:dateTime"
+                   minOccurs="0"/>
+      <xsd:element name="timeout-method"
+                   type="jakartaee:named-methodType"/>
+      <xsd:element name="persistent"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="timezone"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:element name="info"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="trans-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The trans-attributeType specifies how the container must
+        manage the transaction boundaries when delegating a method 
+        invocation to an enterprise bean's business method. 
+        
+        The value must be one of the following: 
+        
+        NotSupported 
+        Supports 
+        Required  
+        RequiresNew 
+        Mandatory 
+        Never 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="NotSupported"/>
+        <xsd:enumeration value="Supports"/>
+        <xsd:enumeration value="Required"/>
+        <xsd:enumeration value="RequiresNew"/>
+        <xsd:enumeration value="Mandatory"/>
+        <xsd:enumeration value="Never"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transaction-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transaction-typeType specifies an enterprise bean's
+        transaction management type.
+        
+        The transaction-type must be one of the two following:
+        
+        Bean
+        Container
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="Bean"/>
+        <xsd:enumeration value="Container"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/ejb/src/main/resources/schema/persistence_3_0.xsd
+++ b/ejb/src/main/resources/schema/persistence_3_0.xsd
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2008, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0 which is available at
+    http://www.eclipse.org/legal/epl-2.0,
+    or the Eclipse Distribution License v. 1.0 which is available at
+    http://www.eclipse.org/org/documents/edl-v10.php.
+
+    SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+-->
+
+<!-- persistence.xml schema -->
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/persistence" 
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:persistence="https://jakarta.ee/xml/ns/persistence"
+  elementFormDefault="qualified" 
+  attributeFormDefault="unqualified" 
+  version="3.0">
+
+   <xsd:annotation>
+     <xsd:documentation><![CDATA[
+
+     This is the XML Schema for the persistence configuration file.
+     The file must be named "META-INF/persistence.xml" in the 
+     persistence archive.
+
+     Persistence configuration files must indicate
+     the persistence schema by using the persistence namespace:
+
+     https://jakarta.ee/xml/ns/persistence
+
+     and indicate the version of the schema by
+     using the version element as shown below:
+
+      <persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+          https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+        version="3.0">
+          ...
+      </persistence>
+
+    ]]></xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:simpleType name="versionType">
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="[0-9]+(\.[0-9]+)*"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- **************************************************** -->
+
+  <xsd:element name="persistence">
+    <xsd:complexType>
+      <xsd:sequence>
+
+        <!-- **************************************************** -->
+
+        <xsd:element name="persistence-unit" 
+                     minOccurs="1" maxOccurs="unbounded">
+          <xsd:complexType>
+            <xsd:annotation>
+              <xsd:documentation>
+
+                Configuration of a persistence unit.
+
+              </xsd:documentation>
+            </xsd:annotation>
+            <xsd:sequence>
+
+            <!-- **************************************************** -->
+
+              <xsd:element name="description" type="xsd:string" 
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Description of this persistence unit.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="provider" type="xsd:string" 
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Provider class that supplies EntityManagers for this 
+                    persistence unit.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="jta-data-source" type="xsd:string" 
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    The container-specific name of the JTA datasource to use.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="non-jta-data-source" type="xsd:string" 
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    The container-specific name of a non-JTA datasource to use.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="mapping-file" type="xsd:string" 
+                           minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    File containing mapping information. Loaded as a resource 
+                    by the persistence provider.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="jar-file" type="xsd:string" 
+                           minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Jar file that is to be scanned for managed classes. 
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="class" type="xsd:string" 
+                           minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Managed class to be included in the persistence unit and
+                    to scan for annotations.  It should be annotated 
+                    with either @Entity, @Embeddable or @MappedSuperclass.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="exclude-unlisted-classes" type="xsd:boolean" 
+                           default="true" minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    When set to true then only listed classes and jars will 
+                    be scanned for persistent classes, otherwise the 
+                    enclosing jar or directory will also be scanned. 
+                    Not applicable to Java SE persistence units.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="shared-cache-mode" 
+                           type="persistence:persistence-unit-caching-type" 
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    Defines whether caching is enabled for the 
+                    persistence unit if caching is supported by the
+                    persistence provider. When set to ALL, all entities 
+                    will be cached. When set to NONE, no entities will
+                    be cached. When set to ENABLE_SELECTIVE, only entities
+                    specified as cacheable will be cached. When set to
+                    DISABLE_SELECTIVE, entities specified as not cacheable
+                    will not be cached. When not specified or when set to
+                    UNSPECIFIED, provider defaults may apply.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="validation-mode" 
+                           type="persistence:persistence-unit-validation-mode-type" 
+                           minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    The validation mode to be used for the persistence unit.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+              </xsd:element>
+
+
+              <!-- **************************************************** -->
+
+              <xsd:element name="properties" minOccurs="0">
+                <xsd:annotation>
+                  <xsd:documentation>
+
+                    A list of standard and vendor-specific properties 
+                    and hints.
+
+                  </xsd:documentation>
+                </xsd:annotation>
+                <xsd:complexType>
+                  <xsd:sequence>
+                    <xsd:element name="property" 
+                                 minOccurs="0" maxOccurs="unbounded">
+                      <xsd:annotation>
+                        <xsd:documentation>
+                          A name-value pair.
+                        </xsd:documentation>
+                      </xsd:annotation>
+                      <xsd:complexType>
+                        <xsd:attribute name="name" type="xsd:string" 
+                                       use="required"/>
+                        <xsd:attribute name="value" type="xsd:string" 
+                                       use="required"/>
+                      </xsd:complexType>
+                    </xsd:element>
+                  </xsd:sequence>
+                </xsd:complexType>
+              </xsd:element>
+
+            </xsd:sequence>
+
+            <!-- **************************************************** -->
+
+            <xsd:attribute name="name" type="xsd:string" use="required">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Name used in code to reference this persistence unit.
+
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:attribute>
+
+            <!-- **************************************************** -->
+
+            <xsd:attribute name="transaction-type" 
+                           type="persistence:persistence-unit-transaction-type">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Type of transactions used by EntityManagers from this 
+                  persistence unit.
+
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:attribute>
+
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="persistence:versionType" 
+                     fixed="3.0" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- **************************************************** -->
+
+  <xsd:simpleType name="persistence-unit-transaction-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum PersistenceUnitTransactionType {JTA, RESOURCE_LOCAL};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="JTA"/>
+      <xsd:enumeration value="RESOURCE_LOCAL"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="persistence-unit-caching-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum SharedCacheMode { ALL, NONE, ENABLE_SELECTIVE, DISABLE_SELECTIVE, UNSPECIFIED};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="ALL"/>
+      <xsd:enumeration value="NONE"/>
+      <xsd:enumeration value="ENABLE_SELECTIVE"/>
+      <xsd:enumeration value="DISABLE_SELECTIVE"/>
+      <xsd:enumeration value="UNSPECIFIED"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+<!-- **************************************************** -->
+
+  <xsd:simpleType name="persistence-unit-validation-mode-type">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        public enum ValidationMode { AUTO, CALLBACK, NONE};
+
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="AUTO"/>
+      <xsd:enumeration value="CALLBACK"/>
+      <xsd:enumeration value="NONE"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/permissions/src/main/resources/schema/permissions_9.xsd
+++ b/permissions/src/main/resources/schema/permissions_9.xsd
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="9">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the application or module declared permissions 9.
+      The declared permissions file must be named "META-INF/permissions.xml" in the
+      application's ear file, or in a module's META-INF/permissions.xml if
+      the module is deployed standalone.  All declared permissions must indicate
+      the declared permissions schema by using the Jakarta EE namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and indicate the version of the schema by
+      using the version element as shown below:
+      
+      <permissions xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee 
+      	https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd"
+      version="9">
+      ...
+      </permisssions>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/permissions_9.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="permissions">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The permissions element is the root element in a
+        declared permissions file. The declared permissions file
+        declares the code based permissions granted to classes and libraries 
+        packaged in the application archive, or in a module if the module is
+        deployed standalone.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+
+<!-- **************************************************** -->
+
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="permission"
+                     maxOccurs="unbounded"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Each permission element declares a permission.  If no permission
+              elements are declared, the application or module needs no special
+              permissions, and the Jakarta EE product may deploy it with no
+              permissions beyond those necessary for the operation of the
+              container.
+              
+              For details on the definition of the 'name' and 'actions'
+              elements, refer to the Java API documentation for the class
+              java.security.Permission, and its derived classes.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+
+<!-- **************************************************** -->
+
+          <xsd:complexType>
+            <xsd:sequence>
+              <xsd:element type="jakartaee:fully-qualified-classType"
+                           name="class-name"/>
+              <xsd:element type="jakartaee:string"
+                           name="name"
+                           minOccurs="0"/>
+              <xsd:element type="jakartaee:string"
+                           name="actions"
+                           minOccurs="0"/>
+            </xsd:sequence>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="version"
+                     type="jakartaee:dewey-versionType"
+                     fixed="9"
+                     use="required">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The required value for the version is 9.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:attribute>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/jsp_3_0.xsd
+++ b/web/src/main/resources/schema/jsp_3_0.xsd
@@ -1,0 +1,365 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      This is the XML Schema for the JSP 3.0 deployment descriptor
+      types.  The JSP 3.0 schema contains all the special
+      structures and datatypes that are necessary to use JSP files
+      from a web application. 
+      
+      The contents of this schema is used by the web-common_5_0.xsd 
+      file to define JSP specific content. 
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jsp-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jsp-configType is used to provide global configuration
+        information for the JSP files in a web application. It has
+        two subelements, taglib and jsp-property-group.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="taglib"
+                   type="jakartaee:taglibType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="jsp-property-group"
+                   type="jakartaee:jsp-property-groupType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jsp-fileType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jsp-file element contains the full path to a JSP file
+        within the web application beginning with a `/'.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:pathType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="jsp-property-groupType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The jsp-property-groupType is used to group a number of
+        files so they can be given global property information.
+        All files so described are deemed to be JSP files.  The
+        following additional properties can be described:
+        
+        - Control whether EL is ignored.
+        - Control whether scripting elements are invalid.
+        - Indicate pageEncoding information.
+        - Indicate that a resource is a JSP document (XML).
+        - Prelude and Coda automatic includes.
+        - Control whether the character sequence #{ is allowed
+        when used as a String literal.
+        - Control whether template text containing only
+        whitespaces must be removed from the response output.
+        - Indicate the default contentType information.
+        - Indicate the default buffering model for JspWriter
+        - Control whether error should be raised for the use of
+        undeclared namespaces in a JSP page.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="el-ignored"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Can be used to easily set the isELIgnored
+            property of a group of JSP pages.  By default, the
+            EL evaluation is enabled for Web Applications using
+            a Servlet 2.4 or greater web.xml, and disabled
+            otherwise.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="page-encoding"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The valid values of page-encoding are those of the
+            pageEncoding page directive.  It is a
+            translation-time error to name different encodings
+            in the pageEncoding attribute of the page directive
+            of a JSP page and in a JSP configuration element
+            matching the page.  It is also a translation-time
+            error to name different encodings in the prolog
+            or text declaration of a document in XML syntax and
+            in a JSP configuration element matching the document.
+            It is legal to name the same encoding through
+            mulitple mechanisms.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="scripting-invalid"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Can be used to easily disable scripting in a
+            group of JSP pages.  By default, scripting is
+            enabled.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="is-xml"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            If true, denotes that the group of resources
+            that match the URL pattern are JSP documents,
+            and thus must be interpreted as XML documents.
+            If false, the resources are assumed to not
+            be JSP documents, unless there is another
+            property group that indicates otherwise.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="include-prelude"
+                   type="jakartaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The include-prelude element is a context-relative
+            path that must correspond to an element in the
+            Web Application.  When the element is present,
+            the given path will be automatically included (as
+            in an include directive) at the beginning of each
+            JSP page in this jsp-property-group.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="include-coda"
+                   type="jakartaee:pathType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The include-coda element is a context-relative
+            path that must correspond to an element in the
+            Web Application.  When the element is present,
+            the given path will be automatically included (as
+            in an include directive) at the end of each
+            JSP page in this jsp-property-group.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="deferred-syntax-allowed-as-literal"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The character sequence #{ is reserved for EL expressions.
+            Consequently, a translation error occurs if the #{
+            character sequence is used as a String literal, unless
+            this element is enabled (true). Disabled (false) by
+            default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="trim-directive-whitespaces"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Indicates that template text containing only whitespaces
+            must be removed from the response output. It has no
+            effect on JSP documents (XML syntax). Disabled (false)
+            by default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-content-type"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The valid values of default-content-type are those of the
+            contentType page directive.  It specifies the default
+            response contentType if the page directive does not include
+            a contentType attribute.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="buffer"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The valid values of buffer are those of the
+            buffer page directive.  It specifies if buffering should be
+            used for the output to response, and if so, the size of the
+            buffer to use.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="error-on-undeclared-namespace"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The default behavior when a tag with unknown namespace is used
+            in a JSP page (regular syntax) is to silently ignore it.  If
+            set to true, then an error must be raised during the translation
+            time when an undeclared tag is used in a JSP page.  Disabled
+            (false) by default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The taglibType defines the syntax for declaring in
+        the deployment descriptor that a tag library is
+        available to the application.  This can be done
+        to override implicit map entries from TLD files and
+        from the container.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="taglib-uri"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A taglib-uri element describes a URI identifying a
+            tag library used in the web application.  The body
+            of the taglib-uri element may be either an
+            absolute URI specification, or a relative URI.
+            There should be no entries in web.xml with the
+            same taglib-uri value.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="taglib-location"
+                   type="jakartaee:pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            the taglib-location element contains the location
+            (as a resource relative to the root of the web
+            application) where to find the Tag Library
+            Description file for the tag library.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/web-app_5_0.xsd
+++ b/web/src/main/resources/schema/web-app_5_0.xsd
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="5.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the Servlet 5.0 deployment descriptor.
+      The deployment descriptor must be named "WEB-INF/web.xml" in the
+      web application's war file.  All Servlet deployment descriptors
+      must indicate the web application schema by using the Jakarta EE
+      namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and by indicating the version of the schema by
+      using the version element as shown below:
+      
+      <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="5.0">
+      ...
+      </web-app>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="web-common_5_0.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="web-app"
+               type="jakartaee:web-appType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-app element is the root of the deployment
+        descriptor for a web application.  Note that the sub-elements
+        of this element can be in the arbitrary order. Because of
+        that, the multiplicity of the elements of distributable,
+        session-config, welcome-file-list, jsp-config, login-config,
+        and locale-encoding-mapping-list was changed from "?" to "*"
+        in this schema.  However, the deployment descriptor instance
+        file must not contain multiple elements of session-config,
+        jsp-config, and login-config. When there are multiple elements of
+        welcome-file-list or locale-encoding-mapping-list, the container
+        must concatenate the element contents.  The multiple occurence
+        of the element distributable is redundant and the container
+        treats that case exactly in the same way when there is only
+        one distributable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="web-common-servlet-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The servlet element contains the name of a servlet.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet"/>
+      <xsd:field xpath="jakartaee:servlet-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-filter-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The filter element contains the name of a filter.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:filter"/>
+      <xsd:field xpath="jakartaee:filter-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-local-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-local-ref-name element contains the name of an 
+          enterprise bean reference. The enterprise 
+          bean reference is an entry in the web
+          application's environment and is relative to the
+          java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-local-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an 
+          enterprise bean reference. The enterprise bean 
+          reference is an entry in the web application's environment 
+          and is relative to the java:comp/env context.  
+          The name must be unique within the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the name of
+          a message destination reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.  The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of a web
+          application's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name
+          must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:key name="web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          A role-name-key is specified to allow the references
+          from the security-role-refs.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:security-role"/>
+      <xsd:field xpath="jakartaee:role-name"/>
+    </xsd:key>
+    <xsd:keyref name="web-common-role-name-references"
+                refer="jakartaee:web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          security-role-ref to a specified role-name.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet/jakartaee:security-role-ref"/>
+      <xsd:field xpath="jakartaee:role-link"/>
+    </xsd:keyref>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-appType">
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="module-name"
+                   type="jakartaee:string"
+                   minOccurs="0"/>
+      <xsd:group ref="jakartaee:web-commonType"/>
+      <xsd:element name="default-context-path"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When specified, this element provides a default context path
+            of the web application. An empty value for this element must cause
+            the web application to be deployed at the root for the container.
+            Otherwise, the default context path must start with
+            a "/" character but not end with a "/" character.
+            Servlet containers may provide vendor specific configuration
+            options that allows specifying a value that overrides the value
+            specified here.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="request-character-encoding"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When specified, this element provides a default request
+            character encoding of the web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="response-character-encoding"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When specified, this element provides a default response
+            character encoding of the web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="deny-uncovered-http-methods"
+                   type="jakartaee:emptyType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            When specified, this element causes uncovered http methods
+            to be denied. For every url-pattern that is the target of a
+            security-constrant, this element causes all HTTP methods that
+            are NOT covered (by a security constraint) at the url-pattern
+            to be denied.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="absolute-ordering"
+                   type="jakartaee:absoluteOrderingType"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="jakartaee:web-common-attributes"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="absoluteOrderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Please see section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:ordering-othersType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:choice>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/web-common_5_0.xsd
+++ b/web/src/main/resources/schema/web-common_5_0.xsd
@@ -1,0 +1,1450 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="5.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the common XML Schema for the Servlet 5.0 deployment descriptor.
+      This file is in turn used by web.xml and web-fragment.xml
+      web application's war file.  All Servlet deployment descriptors
+      must indicate the web common schema by using the Jakarta EE
+      namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and by indicating the version of the schema by
+      using the version element as shown below:
+      
+      <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="5.0">
+      ...
+      </web-app>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/web-common_5_0.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+  <xsd:include schemaLocation="jsp_3_0.xsd"/>
+
+  <xsd:group name="web-commonType">
+    <xsd:choice>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="distributable"
+                   type="jakartaee:emptyType"/>
+      <xsd:element name="context-param"
+                   type="jakartaee:param-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The context-param element contains the declaration
+            of a web application's servlet context
+            initialization parameters.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="filter"
+                   type="jakartaee:filterType"/>
+      <xsd:element name="filter-mapping"
+                   type="jakartaee:filter-mappingType"/>
+      <xsd:element name="listener"
+                   type="jakartaee:listenerType"/>
+      <xsd:element name="servlet"
+                   type="jakartaee:servletType"/>
+      <xsd:element name="servlet-mapping"
+                   type="jakartaee:servlet-mappingType"/>
+      <xsd:element name="session-config"
+                   type="jakartaee:session-configType"/>
+      <xsd:element name="mime-mapping"
+                   type="jakartaee:mime-mappingType"/>
+      <xsd:element name="welcome-file-list"
+                   type="jakartaee:welcome-file-listType"/>
+      <xsd:element name="error-page"
+                   type="jakartaee:error-pageType"/>
+      <xsd:element name="jsp-config"
+                   type="jakartaee:jsp-configType"/>
+      <xsd:element name="security-constraint"
+                   type="jakartaee:security-constraintType"/>
+      <xsd:element name="login-config"
+                   type="jakartaee:login-configType"/>
+      <xsd:element name="security-role"
+                   type="jakartaee:security-roleType"/>
+      <xsd:group ref="jakartaee:jndiEnvironmentRefsGroup"/>
+      <xsd:element name="message-destination"
+                   type="jakartaee:message-destinationType"/>
+      <xsd:element name="locale-encoding-mapping-list"
+                   type="jakartaee:locale-encoding-mapping-listType"/>
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:attributeGroup name="web-common-attributes">
+    <xsd:attribute name="version"
+                   type="jakartaee:web-app-versionType"
+                   use="required"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          deployment descriptor and other related deployment
+          descriptors for this module (e.g., web service
+          descriptors) are complete, or whether the class
+          files available to this module and packaged with
+          this application should be examined for annotations
+          that specify deployment information.
+          
+          If metadata-complete is set to "true", the deployment
+          tool must ignore any annotations that specify deployment
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the deployment tool must examine the class
+          files of the application for annotations, as
+          specified by the specifications.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:attributeGroup>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="auth-constraintType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The auth-constraintType indicates the user roles that
+        should be permitted access to this resource
+        collection. The role-name used here must either correspond
+        to the role-name of one of the security-role elements
+        defined for this web application, or be the specially
+        reserved role-name "*" that is a compact syntax for
+        indicating all roles in the web application. If both "*"
+        and rolenames appear, the container interprets this as all
+        roles.  If no roles are defined, no user is allowed access
+        to the portion of the web application described by the
+        containing security-constraint.  The container matches
+        role names case sensitively when determining access.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="role-name"
+                   type="jakartaee:role-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="auth-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The auth-methodType is used to configure the authentication
+        mechanism for the web application. As a prerequisite to
+        gaining access to any web resources which are protected by
+        an authorization constraint, a user must have authenticated
+        using the configured mechanism. Legal values are "BASIC",
+        "DIGEST", "FORM", "CLIENT-CERT", or a vendor-specific
+        authentication scheme.
+        
+        Used in: login-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="dispatcherType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The dispatcher has five legal values: FORWARD, REQUEST,
+        INCLUDE, ASYNC, and ERROR.
+        
+        A value of FORWARD means the Filter will be applied under
+        RequestDispatcher.forward() calls.
+        A value of REQUEST means the Filter will be applied under
+        ordinary client calls to the path or servlet.
+        A value of INCLUDE means the Filter will be applied under
+        RequestDispatcher.include() calls.
+        A value of ASYNC means the Filter will be applied under
+        calls dispatched from an AsyncContext.
+        A value of ERROR means the Filter will be applied under the
+        error page mechanism.
+        
+        The absence of any dispatcher elements in a filter-mapping
+        indicates a default of applying filters only under ordinary
+        client calls to the path or servlet.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="FORWARD"/>
+        <xsd:enumeration value="INCLUDE"/>
+        <xsd:enumeration value="REQUEST"/>
+        <xsd:enumeration value="ASYNC"/>
+        <xsd:enumeration value="ERROR"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="error-codeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The error-code contains an HTTP error code, ex: 404
+        
+        Used in: error-page
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdPositiveIntegerType">
+        <xsd:pattern value="\d{3}"/>
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="error-pageType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The error-pageType contains a mapping between an error code
+        or exception type to the path of a resource in the web
+        application.
+        
+        Error-page declarations using the exception-type element in
+        the deployment descriptor must be unique up to the class name of
+        the exception-type. Similarly, error-page declarations using the
+        error-code element must be unique in the deployment descriptor
+        up to the status code.
+        
+        If an error-page element in the deployment descriptor does not
+        contain an exception-type or an error-code element, the error
+        page is a default error page.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="error-code"
+                     type="jakartaee:error-codeType"/>
+        <xsd:element name="exception-type"
+                     type="jakartaee:fully-qualified-classType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The exception-type contains a fully qualified class
+              name of a Java exception type.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="location"
+                   type="jakartaee:war-pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The location element contains the location of the
+            resource in the web application relative to the root of
+            the web application. The value of the location must have
+            a leading `/'.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="filterType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The filterType is used to declare a filter in the web
+        application. The filter is mapped to either a servlet or a
+        URL pattern in the filter-mapping element, using the
+        filter-name value to reference. Filters can access the
+        initialization parameters declared in the deployment
+        descriptor at runtime via the FilterConfig interface.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="filter-name"
+                   type="jakartaee:filter-nameType"/>
+      <xsd:element name="filter-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully qualified classname of the filter.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="async-supported"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="init-param"
+                   type="jakartaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The init-param element contains a name/value pair as
+            an initialization param of a servlet filter
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="filter-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Declaration of the filter mappings in this web
+        application is done by using filter-mappingType.
+        The container uses the filter-mapping
+        declarations to decide which filters to apply to a request,
+        and in what order. The container matches the request URI to
+        a Servlet in the normal way. To determine which filters to
+        apply it matches filter-mapping declarations either on
+        servlet-name, or on url-pattern for each filter-mapping
+        element, depending on which style is used. The order in
+        which filters are invoked is the order in which
+        filter-mapping declarations that match a request URI for a
+        servlet appear in the list of filter-mapping elements.The
+        filter-name value must be the value of the filter-name
+        sub-elements of one of the filter declarations in the
+        deployment descriptor.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="filter-name"
+                   type="jakartaee:filter-nameType"/>
+      <xsd:choice minOccurs="1"
+                  maxOccurs="unbounded">
+        <xsd:element name="url-pattern"
+                     type="jakartaee:url-patternType"/>
+        <xsd:element name="servlet-name"
+                     type="jakartaee:servlet-nameType"/>
+      </xsd:choice>
+      <xsd:element name="dispatcher"
+                   type="jakartaee:dispatcherType"
+                   minOccurs="0"
+                   maxOccurs="5"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="nonEmptyStringType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines a string which contains at least one
+        character.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:minLength value="1"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="filter-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The logical name of the filter is declare
+        by using filter-nameType. This name is used to map the
+        filter.  Each filter name is unique within the web
+        application.
+        
+        Used in: filter, filter-mapping
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="form-login-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The form-login-configType specifies the login and error
+        pages that should be used in form based login. If form based
+        authentication is not used, these elements are ignored.
+        
+        Used in: login-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="form-login-page"
+                   type="jakartaee:war-pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The form-login-page element defines the location in the web
+            app where the page that can be used for login can be
+            found.  The path begins with a leading / and is interpreted
+            relative to the root of the WAR.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="form-error-page"
+                   type="jakartaee:war-pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The form-error-page element defines the location in
+            the web app where the error page that is displayed
+            when login is not successful can be found.
+            The path begins with a leading / and is interpreted
+            relative to the root of the WAR.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="http-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        A HTTP method type as defined in HTTP 1.1 section 2.2.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:pattern value="[!-~-[\(\)&#60;&#62;@,;:&#34;/\[\]?=\{\}\\\p{Z}]]+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="load-on-startupType">
+    <xsd:union memberTypes="jakartaee:null-charType xsd:integer"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="null-charType">
+    <xsd:restriction base="xsd:string">
+      <xsd:enumeration value=""/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="login-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The login-configType is used to configure the authentication
+        method that should be used, the realm name that should be
+        used for this application, and the attributes that are
+        needed by the form login mechanism.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="auth-method"
+                   type="jakartaee:auth-methodType"
+                   minOccurs="0"/>
+      <xsd:element name="realm-name"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The realm name element specifies the realm name to
+            use in HTTP Basic authorization.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="form-login-config"
+                   type="jakartaee:form-login-configType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mime-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The mime-mappingType defines a mapping between an extension
+        and a mime type.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The extension element contains a string describing an
+          extension. example: "txt"
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:element name="extension"
+                   type="jakartaee:string"/>
+      <xsd:element name="mime-type"
+                   type="jakartaee:mime-typeType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="mime-typeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The mime-typeType is used to indicate a defined mime type.
+        
+        Example:
+        "text/plain"
+        
+        Used in: mime-mapping
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="[^\p{Cc}^\s]+/[^\p{Cc}^\s]+"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="security-constraintType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The security-constraintType is used to associate
+        security constraints with one or more web resource
+        collections
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="display-name"
+                   type="jakartaee:display-nameType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="web-resource-collection"
+                   type="jakartaee:web-resource-collectionType"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="auth-constraint"
+                   type="jakartaee:auth-constraintType"
+                   minOccurs="0"/>
+      <xsd:element name="user-data-constraint"
+                   type="jakartaee:user-data-constraintType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servletType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The servletType is used to declare a servlet.
+        It contains the declarative data of a
+        servlet. If a jsp-file is specified and the load-on-startup
+        element is present, then the JSP should be precompiled and
+        loaded.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="servlet-name"
+                   type="jakartaee:servlet-nameType"/>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="servlet-class"
+                     type="jakartaee:fully-qualified-classType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The servlet-class element contains the fully
+              qualified class name of the servlet.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="jsp-file"
+                     type="jakartaee:jsp-fileType"/>
+      </xsd:choice>
+      <xsd:element name="init-param"
+                   type="jakartaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="load-on-startup"
+                   type="jakartaee:load-on-startupType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The load-on-startup element indicates that this
+            servlet should be loaded (instantiated and have
+            its init() called) on the startup of the web
+            application. The optional contents of these
+            element must be an integer indicating the order in
+            which the servlet should be loaded. If the value
+            is a negative integer, or the element is not
+            present, the container is free to load the servlet
+            whenever it chooses. If the value is a positive
+            integer or 0, the container must load and
+            initialize the servlet as the application is
+            deployed. The container must guarantee that
+            servlets marked with lower integers are loaded
+            before servlets marked with higher integers. The
+            container may choose the order of loading of
+            servlets with the same load-on-start-up value.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="enabled"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="async-supported"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0"/>
+      <xsd:element name="run-as"
+                   type="jakartaee:run-asType"
+                   minOccurs="0"/>
+      <xsd:element name="security-role-ref"
+                   type="jakartaee:security-role-refType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="multipart-config"
+                   type="jakartaee:multipart-configType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The servlet-mappingType defines a mapping between a
+        servlet and a url pattern.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="servlet-name"
+                   type="jakartaee:servlet-nameType"/>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   minOccurs="1"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="servlet-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The servlet-name element contains the canonical name of the
+        servlet. Each servlet name is unique within the web
+        application.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="session-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The session-configType defines the session parameters
+        for this web application.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="session-timeout"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The session-timeout element defines the default
+            session timeout interval for all sessions created
+            in this web application. The specified timeout
+            must be expressed in a whole number of minutes.
+            If the timeout is 0 or less, the container ensures
+            the default behaviour of sessions is never to time
+            out. If this element is not specified, the container
+            must set its default timeout period.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="cookie-config"
+                   type="jakartaee:cookie-configType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The cookie-config element defines the configuration of the
+            session tracking cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tracking-mode"
+                   type="jakartaee:tracking-modeType"
+                   minOccurs="0"
+                   maxOccurs="3">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The tracking-mode element defines the tracking modes
+            for sessions created by this web application
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The cookie-configType defines the configuration for the
+        session tracking cookies of this web application.
+        
+        Used in: session-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:cookie-nameType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The name that will be assigned to any session tracking
+            cookies created by this web application.
+            The default is JSESSIONID
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="domain"
+                   type="jakartaee:cookie-domainType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The domain name that will be assigned to any session tracking
+            cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="path"
+                   type="jakartaee:cookie-pathType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The path that will be assigned to any session tracking
+            cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="comment"
+                   type="jakartaee:cookie-commentType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The comment that will be assigned to any session tracking
+            cookies created by this web application.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="http-only"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Specifies whether any session tracking cookies created
+            by this web application will be marked as HttpOnly
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="secure"
+                   type="jakartaee:true-falseType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Specifies whether any session tracking cookies created
+            by this web application will be marked as secure.
+            When true, all session tracking cookies must be marked
+            as secure independent of the nature of the request that
+            initiated the corresponding session.
+            When false, the session cookie should only be marked secure
+            if the request that initiated the session was secure.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-age"
+                   type="jakartaee:xsdIntegerType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The lifetime (in seconds) that will be assigned to any
+            session tracking cookies created by this web application.
+            Default is -1
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The name that will be assigned to any session tracking
+        cookies created by this web application.
+        The default is JSESSIONID
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-domainType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The domain name that will be assigned to any session tracking
+        cookies created by this web application.
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The path that will be assigned to any session tracking
+        cookies created by this web application.
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="cookie-commentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The comment that will be assigned to any session tracking
+        cookies created by this web application.
+        
+        Used in: cookie-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:nonEmptyStringType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tracking-modeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The tracking modes for sessions created by this web
+        application
+        
+        Used in: session-config
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="COOKIE"/>
+        <xsd:enumeration value="URL"/>
+        <xsd:enumeration value="SSL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="transport-guaranteeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The transport-guaranteeType specifies that the communication
+        between client and server should be NONE, INTEGRAL, or
+        CONFIDENTIAL. NONE means that the application does not
+        require any transport guarantees. A value of INTEGRAL means
+        that the application requires that the data sent between the
+        client and server be sent in such a way that it can't be
+        changed in transit. CONFIDENTIAL means that the application
+        requires that the data be transmitted in a fashion that
+        prevents other entities from observing the contents of the
+        transmission. In most cases, the presence of the INTEGRAL or
+        CONFIDENTIAL flag will indicate that the use of SSL is
+        required.
+        
+        Used in: user-data-constraint
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="NONE"/>
+        <xsd:enumeration value="INTEGRAL"/>
+        <xsd:enumeration value="CONFIDENTIAL"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="user-data-constraintType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The user-data-constraintType is used to indicate how
+        data communicated between the client and container should be
+        protected.
+        
+        Used in: security-constraint
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="transport-guarantee"
+                   type="jakartaee:transport-guaranteeType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="war-pathType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The elements that use this type designate a path starting
+        with a "/" and interpreted relative to the root of a WAR
+        file.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="/.*"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="web-app-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type contains the recognized versions of
+        web-application supported. It is used to designate the
+        version of the web application.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="5.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-resource-collectionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-resource-collectionType is used to identify the
+        resources and HTTP methods on those resources to which a
+        security constraint applies. If no HTTP methods are specified,
+        then the security constraint applies to all HTTP methods.
+        If HTTP methods are specified by http-method-omission
+        elements, the security constraint applies to all methods
+        except those identified in the collection.
+        http-method-omission and http-method elements are never
+        mixed in the same collection.
+        
+        Used in: security-constraint
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="web-resource-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The web-resource-name contains the name of this web
+            resource collection.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded"/>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="1">
+        <xsd:element name="http-method"
+                     type="jakartaee:http-methodType"
+                     minOccurs="1"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Each http-method names an HTTP method to which the
+              constraint applies.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="http-method-omission"
+                     type="jakartaee:http-methodType"
+                     minOccurs="1"
+                     maxOccurs="unbounded">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              Each http-method-omission names an HTTP method to
+              which the constraint does not apply.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="welcome-file-listType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The welcome-file-list contains an ordered list of welcome
+        files elements.
+        
+        Used in: web-app
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="welcome-file"
+                   type="xsd:string"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The welcome-file element contains file name to use
+            as a default welcome file, such as index.html
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The localeType defines valid locale defined by ISO-639-1
+        and ISO-3166.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[a-z]{2}(_|-)?([\p{L}\-\p{Nd}]{2})?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="encodingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The encodingType defines IANA character sets.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="[^\s]+"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="locale-encoding-mapping-listType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The locale-encoding-mapping-list contains one or more
+        locale-encoding-mapping(s).
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="locale-encoding-mapping"
+                   type="jakartaee:locale-encoding-mappingType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="locale-encoding-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The locale-encoding-mapping contains locale name and
+        encoding name. The locale name must be either "Language-code",
+        such as "ja", defined by ISO-639 or "Language-code_Country-code",
+        such as "ja_JP".  "Country code" is defined by ISO-3166.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="locale"
+                   type="jakartaee:localeType"/>
+      <xsd:element name="encoding"
+                   type="jakartaee:encodingType"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ordering-othersType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element indicates that the ordering sub-element in which
+        it was placed should take special action regarding the ordering
+        of this application resource relative to other application
+        configuration resources.
+        See section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="multipart-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element specifies configuration information related to the
+        handling of multipart/form-data requests.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="location"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The directory location where uploaded files will be stored
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-file-size"
+                   type="xsd:long"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The maximum size limit of uploaded files
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="max-request-size"
+                   type="xsd:long"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The maximum size limit of multipart/form-data requests
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="file-size-threshold"
+                   type="xsd:integer"
+                   minOccurs="0"
+                   maxOccurs="1">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The size threshold after which an uploaded file will be
+            written to disk
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/web-facelettaglibrary_3_0.xsd
+++ b/web/src/main/resources/schema/web-facelettaglibrary_3_0.xsd
@@ -1,0 +1,751 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            xmlns:xml="http://www.w3.org/XML/1998/namespace"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.0">
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>The XML Schema for the Tag Libraries in the Jakarta Server Faces
+      Standard Facelets View Declaration Language (Facelets VDL)
+      (Version 3.0).</p>
+      
+      <p>Jakarta Server Faces 3.0 Facelet Tag Libraries that wish to conform to 
+      this schema must declare it in the following manner.</p>
+      
+      &lt;facelet-taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibary_3_0.xsd"
+      version="3.0"&gt;
+      
+      ...
+      
+      &lt;/facelet-taglib&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facelettaglibary_3_0.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="facelet-taglib"
+               type="jakartaee:facelet-taglibType">
+    <xsd:unique name="facelet-taglib-tagname-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          tag-names must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:tag"/>
+      <xsd:field xpath="jakartaee:tag-name"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Behavior IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Converter IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>
+          
+          Validator IDs must be unique within a document.
+          
+          </p>
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        The top level XML element in a facelet tag library XML file.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="library-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:sequence>
+          <xsd:element name="namespace"
+                       type="jakartaee:string"/>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="short-name"
+                       type="jakartaee:string">
+            <xsd:annotation>
+              <xsd:documentation>
+                <![CDATA[
+                <p>
+                
+                An advisory short name for usages of tags from this tag library.
+                
+                </p>
+                ]]>
+              </xsd:documentation>
+            </xsd:annotation>
+          </xsd:element>
+          <xsd:element minOccurs="0"
+                       maxOccurs="1"
+                       name="composite-library-name"
+                       type="jakartaee:string"/>
+          <xsd:choice minOccurs="0"
+                      maxOccurs="unbounded">
+            <xsd:element name="tag"
+                         type="jakartaee:facelet-taglib-tagType"/>
+            <xsd:element name="function"
+                         type="jakartaee:facelet-taglib-functionType"/>
+          </xsd:choice>
+        </xsd:sequence>
+      </xsd:choice>
+      <xsd:element name="taglib-extension"
+                   type="jakartaee:facelet-taglib-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:facelet-taglib-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for facelet-taglib. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>If the tag library XML
+        file contains individual tag declarations rather than pointing
+        to a library-class or a declaring a composite-library name, the
+        individual tags are enclosed in tag elements.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="tag-name"
+                   type="jakartaee:facelet-taglib-canonical-nameType"/>
+      <xsd:choice>
+        <xsd:element name="handler-class"
+                     type="jakartaee:fully-qualified-classType"/>
+        <xsd:element name="behavior"
+                     type="jakartaee:facelet-taglib-tag-behaviorType"/>
+        <xsd:element name="component"
+                     type="jakartaee:facelet-taglib-tag-componentType"/>
+        <xsd:element name="converter"
+                     type="jakartaee:facelet-taglib-tag-converterType"/>
+        <xsd:element name="validator"
+                     type="jakartaee:facelet-taglib-tag-validatorType"/>
+        <xsd:element name="source"
+                     type="jakartaee:string"/>
+      </xsd:choice>
+      <xsd:element name="attribute"
+                   type="jakartaee:facelet-taglib-tag-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:facelet-taglib-tag-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>The attribute element defines an attribute for the nesting
+        tag. The attribute element may have several subelements
+        defining:</p>
+        
+        <dl>
+        
+        <dt>description</dt><dd><p> a description of the attribute
+        </p></dd>
+        
+        <dt>name</dt><dd><p> the name of the attribute
+        </p></dd>
+        
+        <dt>required</dt><dd><p> whether the attribute is required or
+        optional
+        </p></dd>
+        
+        <dt>type</dt><dd><p> the type of the attribute
+        </p></dd>
+        
+        </dl>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:xsdNMTOKENType"/>
+      <xsd:element name="required"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>Defines if the nesting attribute is required or
+            optional.</p>
+            
+            <p>If not present then the default is "false", i.e
+            the attribute is optional.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="type"
+                     type="jakartaee:fully-qualified-classType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the Java type of the attributes
+              value. If this element is omitted, the
+              expected type is assumed to be
+              "java.lang.Object".</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="method-signature"
+                     type="jakartaee:string"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p>
+              
+              Defines the method signature for a MethodExpression-
+              enabled attribute.  The syntax of the method-signature
+              element is as follows (taken from the function-signature
+              EBNF in web-jsptaglibrary_2_1.xsd):</p>
+              
+              <code>
+              
+              <p>MethodSignature ::= ReturnType S MethodName S? '(' S? Parameters? S? ')'</p>
+              
+              <p>ReturnType        ::= Type</p>
+              
+              <p>MethodName        ::= Identifier</p>
+              
+              <p>Parameters        ::= Parameter | ( Parameter S? ',' S? Parameters )</p>
+              
+              <p>Parameter         ::= Type</p>
+              
+              </code>
+              
+              <p>Where:</p>
+              
+              <ul>
+              
+              <li><p><code>Type</code> is a basic type or a fully qualified
+              Java class name (including package name), as per the 'Type'
+              production in the Java Language Specification, Second Edition,
+              Chapter 18.</p></li>
+              
+              <li><p><code>Identifier</code> is a Java identifier, as per the
+              'Identifier' production in the Java Language Specification,
+              Second Edition, Chapter 18.</p></li>
+              
+              </ul>
+              
+              <p>Example:</p>
+              
+              <p><code>java.lang.String nickName( java.lang.String, int )</code></p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for tag It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        If the tag library XML file contains individual function
+        declarations rather than pointing to a library-class or a
+        declaring a composite-library name, the individual functions are
+        enclosed in function elements.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="function-name"
+                   type="jakartaee:string"/>
+      <xsd:element name="function-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="function-signature"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the behavior element encapsulates
+        information specific to a Faces Behavior.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="behavior-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:facelet-taglib-tag-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for behavior. It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2
+        changed_modified_2_3">Within</span> a tag element, the component
+        element encapsulates information specific to a Faces UIComponent.</p>
+        
+        <div class="changed_added_2_2 changed_deleted_2_3">
+        
+        <p>As of 3.0 of the specification, this requirement is no longer
+        present: This element must have exactly one of
+        <code>&lt;component-type&gt;</code>, <code>&lt;resource-id&gt;</code>,
+        or <code>&lt;handler-class&gt;</code> among its child elements.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="renderer-type"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="resource-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A valid resource identifier
+            as specified in the spec prose document section
+            2.6.1.3.  For example:</p>
+            
+            <p><code>&lt;resource-id&gt;myCC/ccName.xhtml&lt;/resource-id&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-extension"
+                   type="jakartaee:facelet-taglib-tag-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for component It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the converter element encapsulates
+        information specific to a Faces Converter.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="converter-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:facelet-taglib-tag-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for converter It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Within a tag element, the validator element encapsulates
+        information specific to a Faces Validator.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element minOccurs="1"
+                   maxOccurs="1"
+                   name="validator-id"
+                   type="jakartaee:string"/>
+      <xsd:element minOccurs="0"
+                   maxOccurs="1"
+                   name="handler-class"
+                   type="jakartaee:fully-qualified-classType"/>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:facelet-taglib-tag-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-tag-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        Extension element for validator It may contain
+        implementation specific content.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="facelet-taglib-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        This type contains the recognized versions of
+        facelet-taglib supported.
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="3.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="facelet-taglib-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>
+        
+        <p>Defines the canonical name of a tag or attribute being
+        defined.</p>
+        
+        <p>The name must conform to the lexical rules for an NCName</p>
+        
+        </p>
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:NCName">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/web-facesconfig_3_0.xsd
+++ b/web/src/main/resources/schema/web-facesconfig_3_0.xsd
@@ -1,0 +1,3842 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            attributeFormDefault="unqualified"
+            elementFormDefault="qualified"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            version="3.0"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      <p>The XML Schema for the Jakarta Server Faces Application
+      Configuration File (Version 3.0).</p>
+      
+      <p>All JavaServer Faces configuration files must indicate
+      the JavaServer Faces schema by indicating the JavaServer
+      Faces namespace:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee</p>
+      
+      <p>and by indicating the version of the schema by
+      using the version element as shown below:</p>
+      
+      <pre>&lt;faces-config xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="3.0"&gt;
+      ...
+      &lt;/faces-config&gt;</pre>
+      
+      <p>The instance documents may indicate the published
+      version of the schema using xsi:schemaLocation attribute
+      for jakartaee namespace with the following location:</p>
+      
+      <p>https://jakarta.ee/xml/ns/jakartaee/web-facesconfig_3_0.xsd</p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="faces-config"
+               type="jakartaee:faces-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>The "faces-config" element is the root of the configuration
+        information hierarchy, and contains nested elements for all
+        of the other configuration settings.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="faces-config-behavior-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>Behavior IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:behavior"/>
+      <xsd:field xpath="jakartaee:behavior-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>Converter IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-converter-for-class-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p>'converter-for-class' element values must be unique
+          within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:converter"/>
+      <xsd:field xpath="jakartaee:converter-for-class"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-validator-ID-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p> Validator IDs must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:validator"/>
+      <xsd:field xpath="jakartaee:validator-id"/>
+    </xsd:unique>
+    <xsd:unique name="faces-config-managed-bean-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p> Managed bean names must be unique within a document.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:managed-bean"/>
+      <xsd:field xpath="jakartaee:managed-bean-name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "faces-config" element is the root of the configuration
+        information hierarchy, and contains nested elements for all
+        of the other configuration settings.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="application"
+                   type="jakartaee:faces-config-applicationType"/>
+      <xsd:element name="ordering"
+                   type="jakartaee:faces-config-orderingType"/>
+      <xsd:element name="absolute-ordering"
+                   type="jakartaee:faces-config-absoluteOrderingType"
+                   minOccurs="0"/>
+      <xsd:element name="factory"
+                   type="jakartaee:faces-config-factoryType"/>
+      <xsd:element name="component"
+                   type="jakartaee:faces-config-componentType"/>
+      <xsd:element name="converter"
+                   type="jakartaee:faces-config-converterType"/>
+      <xsd:element name="managed-bean"
+                   type="jakartaee:faces-config-managed-beanType"/>
+      <xsd:element name="flow-definition"
+                   type="jakartaee:faces-config-flow-definitionType"/>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> <span class="changed_modified_2_2">The</span> "name" element 
+            within the top level "faces-config"
+            element declares the name of this application
+            configuration resource.  Such names are used
+            in the document ordering scheme specified in section
+            JSF.11.4.6.</p>
+            
+            <p class="changed_added_2_2">This value is taken to be the 
+            defining document id of any &lt;flow-definition&gt; elements 
+            defined in this Application Configuration Resource file.  If this
+            element is not specified, the runtime must take the empty string 
+            as its value.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="navigation-rule"
+                   type="jakartaee:faces-config-navigation-ruleType"/>
+      <xsd:element name="protected-views"
+                   type="jakartaee:faces-config-protected-viewsType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="referenced-bean"
+                   type="jakartaee:faces-config-referenced-beanType"/>
+      <xsd:element name="render-kit"
+                   type="jakartaee:faces-config-render-kitType"/>
+      <xsd:element name="lifecycle"
+                   type="jakartaee:faces-config-lifecycleType"/>
+      <xsd:element name="validator"
+                   type="jakartaee:faces-config-validatorType"/>
+      <xsd:element name="behavior"
+                   type="jakartaee:faces-config-behaviorType"/>
+      <xsd:element name="faces-config-extension"
+                   type="jakartaee:faces-config-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attribute name="metadata-complete"
+                   type="xsd:boolean"
+                   use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The metadata-complete attribute defines whether this
+          JavaServer Faces application is complete, or whether
+          the class files available to this module and packaged with
+          this application should be examined for annotations
+          that specify configuration information.
+          
+          This attribute is only inspected on the application 
+          configuration resource file located at "WEB-INF/faces-config.xml".
+          The presence of this attribute on any application configuration
+          resource other than the one located at "WEB-INF/faces-config.xml",
+          including any files named using the jakarta.faces.CONFIG_FILES
+          attribute, must be ignored.
+          
+          If metadata-complete is set to "true", the JavaServer Faces
+          runtime must ignore any annotations that specify configuration
+          information, which might be present in the class files
+          of the application.
+          
+          If metadata-complete is not specified or is set to
+          "false", the JavaServer Faces runtime must examine the class
+          files of the application for annotations, as specified by
+          the specification.
+          
+          If "WEB-INF/faces-config.xml" is not present, the JavaServer
+          Faces runtime will assume metadata-complete to be "false".
+          
+          The value of this attribute will have no impact on
+          runtime annotations such as @ResourceDependency or
+          @ListenerFor.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="version"
+                   type="jakartaee:faces-config-versionType"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for faces-config.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Please see section JSF.11.4.6 for the specification of this element.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="after"
+                   type="jakartaee:faces-config-ordering-orderingType"
+                   minOccurs="0"/>
+      <xsd:element name="before"
+                   type="jakartaee:faces-config-ordering-orderingType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ordering-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element contains a sequence of "id" elements, each of which
+        refers to an application configuration resource by the "id"
+        declared on its faces-config element.  This element can also contain
+        a single "others" element which specifies that this document comes
+        before or after other documents within the application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:faces-config-ordering-othersType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ordering-othersType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element indicates that the ordering sub-element in which
+        it was placed should take special action regarding the ordering
+        of this application resource relative to other
+        application configuration resources.  See section JSF.11.4.6
+        for the complete specification.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-absoluteOrderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Only relevant if this is placed within the /WEB-INF/faces-config.xml.
+        Please see section JSF.11.4.6 for the specification for details.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:faces-config-ordering-othersType"
+                   minOccurs="0"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-applicationType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "application" element provides a mechanism to define the
+        various per-application-singleton implementation artifacts for
+        a particular web application that is utilizing
+        JavaServer Faces.  For nested elements that are not specified,
+        the Jakarta Server Faces implementation must provide a suitable 
+        default.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="action-listener"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "action-listener" element contains the fully
+            qualified class name of the concrete
+            ActionListener implementation class that will be
+            called during the Invoke Application phase of the
+            request processing lifecycle.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-render-kit-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "default-render-kit-id" element allows the
+            application to define a renderkit to be used other
+            than the standard one.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="message-bundle"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The base name of a resource bundle representing
+            the message resources for this application.  See
+            the JavaDocs for the "java.util.ResourceBundle"
+            class for more information on the syntax of
+            resource bundle names.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="navigation-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "navigation-handler" element contains the
+            fully qualified class name of the concrete
+            NavigationHandler implementation class that will
+            be called during the Invoke Application phase
+            of the request processing lifecycle, if the
+            default ActionListener (provided by the Jakarta Server 
+            Faces implementation) is used.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "view-handler" element contains the fully
+            qualified class name of the concrete ViewHandler
+            implementation class that will be called during
+            the Restore View and Render Response phases of the
+            request processing lifecycle.  The faces
+            implementation must provide a default
+            implementation of this class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="state-manager"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "state-manager" element contains the fully
+            qualified class name of the concrete StateManager
+            implementation class that will be called during
+            the Restore View and Render Response phases of the
+            request processing lifecycle.  The faces
+            implementation must provide a default
+            implementation of this class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="el-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "el-resolver" element contains the fully
+            qualified class name of the concrete
+            jakarta.el.ELResolver implementation class
+            that will be used during the processing of
+            EL expressions.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-resolver" element contains the fully
+            qualified class name of the concrete
+            PropertyResolver implementation class that will
+            be used during the processing of value binding
+            expressions.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="variable-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "variable-resolver" element contains the fully
+            qualified class name of the concrete
+            VariableResolver implementation class that will
+            be used during the processing of value binding
+            expressions.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "resource-handler" element contains the
+            fully qualified class name of the concrete
+            ResourceHandler implementation class that
+            will be used during rendering and decoding
+            of resource requests The standard
+            constructor based decorator pattern used for
+            other application singletons will be
+            honored.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="resource-library-contracts"
+                   type="jakartaee:faces-config-application-resource-library-contractsType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "resource-library-contracts" element
+            specifies the mappings between views in the application and resource
+            library contracts that, if present in the application, must be made
+            available for use as templates of the specified views.
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-expression-handler"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3">The "search-expression-handler"
+            element contains the fully qualified class name of the
+            concrete jakarta.faces.component.search.SearchExpressionHandler
+            implementation class that will be used for processing of a
+            search expression.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-keyword-resolver"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The "search-keyword-resolver"
+            element contains the fully qualified class name of the
+            concrete jakarta.faces.component.search.SearchKeywordResolver
+            implementation class that will be used during the processing
+            of a search expression keyword.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="system-event-listener"
+                   type="jakartaee:faces-config-system-event-listenerType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="locale-config"
+                   type="jakartaee:faces-config-locale-configType"/>
+      <xsd:element name="resource-bundle"
+                   type="jakartaee:faces-config-application-resource-bundleType"/>
+      <xsd:element name="application-extension"
+                   type="jakartaee:faces-config-application-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="default-validators"
+                   type="jakartaee:faces-config-default-validatorsType"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-bundleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The resource-bundle element inside the application element
+        references a java.util.ResourceBundle instance by name
+        using the var element.  ResourceBundles referenced in this
+        manner may be returned by a call to
+        Application.getResourceBundle() passing the current
+        FacesContext for this request and the value of the var
+        element below.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="base-name"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The fully qualified class name of the
+            java.util.ResourceBundle instance.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="var"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The name by which this ResourceBundle instance
+            is retrieved by a call to
+            Application.getResourceBundle().</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-library-contractsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">The "resource-library-contracts" element
+        specifies the mappings between views in the application and resource
+        library contracts that, if present in the application, must be made
+        available for use as templates of the specified views.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="contract-mapping"
+                   type="jakartaee:faces-config-application-resource-library-contracts-contract-mappingType"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p classes="changed_added_2_2">Declare a mapping between a collection
+            of views in the application and the list of contracts (if present in the application)
+            that may be used as a source for templates and resources for those views.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-resource-library-contracts-contract-mappingType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">The "contract-mapping" element
+        specifies the mappings between a collection of views in the application and resource
+        library contracts that, if present in the application, must be made
+        available for use as templates of the specified views.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "url-pattern" element
+            specifies the collection of views in this application that 
+            are allowed to use the corresponding contracts.
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="contracts"
+                   type="jakartaee:string"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The "contracts" element
+            is a comma separated list of resource library contracts that,
+            if available to the application, may be used by the views
+            matched by the corresponding "url-pattern"
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-application-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for application.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-factoryType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "factory" element provides a mechanism to define the
+        various Factories that comprise parts of the implementation
+        of JavaServer Faces.  For nested elements that are not
+        specified, the Jakarta Server Faces implementation must provide a 
+        suitable default.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="application-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "application-factory" element contains the
+            fully qualified class name of the concrete
+            ApplicationFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(APPLICATION_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="exception-handler-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "exception-handler-factory" element contains the
+            fully qualified class name of the concrete
+            ExceptionHandlerFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(EXCEPTION_HANDLER_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="external-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "external-context-factory" element contains the
+            fully qualified class name of the concrete
+            ExternalContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(EXTERNAL_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="faces-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "faces-context-factory" element contains the
+            fully qualified class name of the concrete
+            FacesContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FACES_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facelet-cache-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "facelet-cache-factory" element contains the
+            fully qualified class name of the concrete
+            FaceletCacheFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FACELET_CACHE_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="partial-view-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "partial-view-context-factory" element contains the
+            fully qualified class name of the concrete
+            PartialViewContextFactory implementation class that will
+            be called when FactoryFinder.getFactory
+            (FactoryFinder.PARTIAL_VIEW_CONTEXT_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lifecycle-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "lifecycle-factory" element contains the fully
+            qualified class name of the concrete LifecycleFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(LIFECYCLE_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view-declaration-language-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "view-declaration-language-factory" element contains
+            the fully qualified class name of the concrete
+            ViewDeclarationLanguageFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(VIEW_DECLARATION_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tag-handler-delegate-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "tag-handler-delegate-factory" element contains
+            the fully qualified class name of the concrete
+            ViewDeclarationLanguageFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(TAG_HANDLER_DELEGATE_FACTORY) is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="render-kit-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-factory" element contains the fully
+            qualified class name of the concrete RenderKitFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(RENDER_KIT_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="visit-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "visit-context-factory" element contains the fully
+            qualified class name of the concrete VisitContextFactory
+            implementation class that will be called when
+            FactoryFinder.getFactory(VISIT_CONTEXT_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flash-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "flash-factory" element contains the
+            fully qualified class name of the concrete
+            FaceletFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FLASH_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flow-handler-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "flow-handler-factory" element contains the
+            fully qualified class name of the concrete
+            FlowHandlerFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(FLOW_HANDLER_FACTORY) is
+            called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-window-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The "client-window-factory" element contains the fully 
+            qualified class name of the concrete ClientWindowFactory implementation class that 
+            will be called when FactoryFinder.getFactory(CLIENT_WINDOW_FACTORY) is called.</p>  
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="search-expression-context-factory"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_3"> The
+            "search-expression-context-factory" element contains the
+            fully qualified class name of the concrete
+            SearchExpressionContextFactory implementation class that will
+            be called when
+            FactoryFinder.getFactory(SEARCH_EXPRESSION_CONTEXT_FACTORY)
+            is called.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="factory-extension"
+                   type="jakartaee:faces-config-factory-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-factory-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for factory.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "attribute" element represents a named, typed, value
+        associated with the parent UIComponent via the generic
+        attributes mechanism.</p>
+        
+        <p>Attribute names must be unique within the scope of the parent
+        (or related) component.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="attribute-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "attribute-name" element represents the name under
+            which the corresponding value will be stored, in the
+            generic attributes of the UIComponent we are related
+            to.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "attribute-class" element represents the Java type
+            of the value associated with this attribute name.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-value"
+                   type="jakartaee:faces-config-default-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="suggested-value"
+                   type="jakartaee:faces-config-suggested-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="attribute-extension"
+                   type="jakartaee:faces-config-attribute-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-attribute-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for attribute.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-componentType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "component" element represents a concrete UIComponent
+        implementation class that should be registered under the
+        specified type identifier, along with its associated
+        properties and attributes.  Component types must be unique
+        within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        are recognized by the implementation logic of this component.
+        Nested "property" elements identify JavaBeans properties of
+        the component class that may be exposed for manipulation
+        via tools.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-type" element represents the name under
+            which the corresponding UIComponent class should be
+            registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="component-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-class" element represents the fully
+            qualified class name of a concrete UIComponent
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet"
+                   type="jakartaee:faces-config-facetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="component-extension"
+                   type="jakartaee:faces-config-component-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-component-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for component.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-locale" element declares the default locale
+        for this application instance.</p>
+        
+        <p class="modified_added_2_3">
+        To facilitate BCP 47 this element first needs to be parsed by the
+        Locale.forLanguageTag method. If it does not return a Locale with
+        a language the old specification below needs to take effect.
+        </p>
+        
+        <p>It must be specified as :language:[_:country:[_:variant:]]
+        without the colons, for example "ja_JP_SJIS".  The
+        separators between the segments may be '-' or '_'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-localeType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-value" contains the value for the property or
+        attribute in which this element resides.  This value differs
+        from the "suggested-value" in that the property or attribute
+        must take the value, whereas in "suggested-value" taking the
+        value is optional.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-el-expressionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> EL expressions present within a faces config file
+        must start with the character sequence of '#{' and
+        end with '}'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="#\{.*\}"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-facetType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Define the name and other design-time information for a facet
+        that is associated with a renderer or a component.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="facet-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "facet-name" element represents the facet name
+            under which a UIComponent will be added to its parent.
+            It must be of type "Identifier".</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet-extension"
+                   type="jakartaee:faces-config-facet-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-facet-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for facet.  It may contain implementation
+        specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-from-view-idType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p><span class="changed_modified_2_2">The</span>
+        value of from-view-id must contain one of the following
+        values:</p>
+        
+        <ul>
+        
+        <li><p>The exact match for a view identifier that is recognized
+        by the the ViewHandler implementation being used (such as
+        "/index.jsp" if you are using the default ViewHandler).</p></li>
+        
+        <li><p class="changed_added_2_2">The exact match of a flow node id
+        in the current flow, or a flow id of another flow.</p></li>
+        
+        <li><p> A proper prefix of a view identifier, plus a trailing
+        "*" character.  This pattern indicates that all view
+        identifiers that match the portion of the pattern up to the
+        asterisk will match the surrounding rule.  When more than one
+        match exists, the match with the longest pattern is selected.
+        </p></li>
+        
+        <li><p>An "*" character, which means that this pattern applies
+        to all view identifiers.  </p></li>
+        
+        </ul>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-from-actionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "from-action" element contains an action reference
+        expression that must have been executed (by the default
+        ActionListener for handling application level events)
+        in order to select the navigation rule.  If not specified,
+        this rule will be relevant no matter which action reference
+        was executed (or if no action reference was executed).</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-ifType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p>The "if" element defines a condition that must resolve
+        to true in order for the navigation case on which it is
+        defined to be matched, with the existing match criteria
+        (action method and outcome) as a prerequiste, if present.
+        The condition is defined declaratively using a value
+        expression in the body of this element. The expression is
+        evaluated at the time the navigation case is being matched.
+        If the "from-outcome" is omitted and this element is
+        present, the navigation handler will match a null outcome
+        and use the condition return value to determine if the
+        case should be considered a match.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>When used in a <code>&lt;switch&gt;</code> within a flow, if the
+        expresion returns <code>true</code>, the
+        <code>&lt;from-outcome&gt;</code> sibling element's outcome is used as
+        the id of the node in the flow graph to which control must be
+        passed.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-parameter-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2"></p>
+        
+        <div class="changed_added_2_2">
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-converterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "converter" element represents a concrete Converter
+        implementation class that should be registered under the
+        specified converter identifier.  Converter identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Converter.  Nested "property"
+        elements identify JavaBeans properties of the Converter
+        implementation class that may be configured to affect the
+        operation of the Converter.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:choice>
+        <xsd:element name="converter-id"
+                     type="jakartaee:string">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p> The "converter-id" element represents the
+              identifier under which the corresponding
+              Converter class should be registered.</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="converter-for-class"
+                     type="jakartaee:fully-qualified-classType">
+          <xsd:annotation>
+            <xsd:documentation>
+              <![CDATA[
+              <p> The "converter-for-class" element represents the
+              fully qualified class name for which a Converter
+              class will be registered.</p>
+              
+              ]]>
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="converter-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "converter-class" element represents the fully
+            qualified class name of a concrete Converter
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Converter.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Converter implementation class
+            that may be configured to affect the operation of
+            the Converter.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="converter-extension"
+                   type="jakartaee:faces-config-converter-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-converter-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for converter.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-lifecycleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "lifecycle" element provides a mechanism to specify
+        modifications to the behaviour of the default Lifecycle
+        implementation for this web application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="phase-listener"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "phase-listener" element contains the fully
+            qualified class name of the concrete PhaseListener
+            implementation class that will be registered on
+            the Lifecycle.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="lifecycle-extension"
+                   type="jakartaee:faces-config-lifecycle-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-lifecycle-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for lifecycle.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The localeType defines valid locale defined by ISO-639-1
+        and ISO-3166.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:string">
+      <xsd:pattern value="([a-z]{2})[_|\-]?([\p{L}]{2})?[_|\-]?(\w+)?"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-locale-configType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "locale-config" element allows the app developer to
+        declare the supported locales for this application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="default-locale"
+                   type="jakartaee:faces-config-default-localeType"
+                   minOccurs="0"/>
+      <xsd:element name="supported-locale"
+                   type="jakartaee:faces-config-supported-localeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-default-validatorsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "default-validators" element allows the app developer to
+        register a set of validators, referenced by identifier, that
+        are automatically assigned to any EditableValueHolder component
+        in the application, unless overridden or disabled locally.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="validator-id"
+                   type="jakartaee:string"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-id" element represents the identifier
+            of a registered validator.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-managed-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "managed-bean" element represents a JavaBean, of a
+        particular class, that will be dynamically instantiated
+        at runtime (by the default VariableResolver implementation)
+        if it is referenced as the first element of a value binding
+        expression, and no corresponding bean can be identified in
+        any scope.  In addition to the creation of the managed bean,
+        and the optional storing of it into the specified scope,
+        the nested managed-property elements can be used to
+        initialize the contents of settable JavaBeans properties of
+        the created instance.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="managed-bean-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "managed-bean-name" element represents the
+            attribute name under which a managed bean will
+            be searched for, as well as stored (unless the
+            "managed-bean-scope" value is "none").</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="managed-bean-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "managed-bean-class" element represents the fully
+            qualified class name of the Java class that will be
+            used`to instantiate a new instance if creation of the
+            specified`managed bean is requested.</p>
+            
+            <p>The specified class must conform to standard JavaBeans
+            conventions.  In particular, it must have a public
+            zero-arguments constructor, and zero or more public
+            property setters.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="managed-bean-scope"
+                   type="jakartaee:faces-config-managed-bean-scopeOrNoneType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "managed-bean-scope" element represents the scope
+            into which a newly created instance of the specified
+            managed bean will be stored (unless the value is
+            "none").</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="managed-property"
+                     type="jakartaee:faces-config-managed-propertyType"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+        <xsd:element name="map-entries"
+                     type="jakartaee:faces-config-map-entriesType"/>
+        <xsd:element name="list-entries"
+                     type="jakartaee:faces-config-list-entriesType"/>
+      </xsd:choice>
+      <xsd:element name="managed-bean-extension"
+                   type="jakartaee:faces-config-managed-bean-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="eager"
+                   type="xsd:boolean"
+                   use="optional">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p> This attribute is only considered when associated with
+          an application-scoped managed bean. If the value of the eager
+          attribute is true the runtime must instantiate this class
+          and store the instance within the application scope when the
+          application starts.</p>
+          
+          <p>If eager is unspecified or is false, the default "lazy"
+          instantiation and scoped storage of the managed bean
+          will occur.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definitionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Top level element for a flow
+        definition.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>If there is no <code>&lt;start-node&gt;</code> element declared, it
+        is assumed to be <code>&lt;flowName&gt;.xhtml</code>.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="start-node"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Declare the id of the starting node in the
+            flow graph.  The start node may be any of the node types mentioned in
+            the class javadocs for <code><a target="_"
+            href="jakarta/faces/flow/FlowHandler.html">FlowHandler</a></code>.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="view"
+                   type="jakartaee:faces-config-flow-definition-viewType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="switch"
+                   type="jakartaee:faces-config-flow-definition-switchType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="flow-return"
+                   type="jakartaee:faces-config-flow-definition-flow-returnType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="navigation-rule"
+                   type="jakartaee:faces-config-navigation-ruleType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="flow-call"
+                   type="jakartaee:faces-config-flow-definition-flow-callType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="method-call"
+                   type="jakartaee:faces-config-flow-definition-faces-method-callType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="initializer"
+                   type="jakartaee:faces-config-flow-definition-initializerType"
+                   minOccurs="0"/>
+      <xsd:element name="finalizer"
+                   type="jakartaee:faces-config-flow-definition-finalizerType"
+                   minOccurs="0"/>
+      <xsd:element name="inbound-parameter"
+                   type="jakartaee:faces-config-flow-definition-inbound-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow.  The id
+          must be unique within the Application configuration Resource
+          file in which this flow is defined.  The value of this attribute, 
+          combined with the value of the &lt;faces-config&gt;&lt;name&gt; element
+          must globally identify the flow within the application.<p> 
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-faces-method-callType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Invoke a method, passing parameters if necessary.
+        The return from the method is used as the outcome for where to go next in the
+        flow.  If the method is a void method, the default outcome is used.<p> 
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method"
+                   type="jakartaee:faces-config-flow-definition-faces-method-call-methodType"/>
+      <xsd:element name="default-outcome"
+                   type="jakartaee:string"/>
+      <xsd:element name="parameter"
+                   type="jakartaee:faces-config-flow-definition-flow-call-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A parameter to pass when calling the method
+            identified in the "method" element that is a sibling of this element.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-faces-method-call-methodType">
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A parameter to pass when calling the method
+        identified in the "method" element that is a sibling of this element.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="class"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The optional "class" element within a "parameter" element 
+            will be interpreted as the fully qualified class name for the type
+            of the "value" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "parameter"
+            must be a literal string or an EL Expression whose "get" will be called when the "method"
+            associated with this element is invoked.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-viewType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a view node in a flow graph.</p>
+        
+        <p>This element must contain exactly one
+        <code>&lt;vdl-document&gt;</code> element.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="vdl-document"
+                   type="jakartaee:pathType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2 changed_modified_2_3">
+            Define the path to the vdl-document for the enclosing view.
+            <p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this view.  It must be
+          unique within the flow.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-switchType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a switch node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain one or more
+        <code>&lt;case&gt;</code> elements.  When control passes to the
+        <code>&lt;switch&gt;</code> node, each of the cases must be considered
+        in order and control must past to the <code>&lt;from-outcome&gt;</code>
+        of the first one whose <code>&lt;if&gt;</code> expression evaluates to 
+        <code>true</code>.</p>
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="case"
+                   type="jakartaee:faces-config-flow-definition-switch-caseType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Defines a case that must be
+            considered in the list of cases in the
+            <code>&lt;switch&gt;</code>.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">Defines the default case that will
+            be taken if none of the other cases in the
+            <code>&lt;switch&gt;</code> are taken.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this switch.  It must be
+          unique within the flow.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-switch-caseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Defines a case that will
+        be considered in the <code>&lt;switch&gt;</code>.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="if"
+                   type="jakartaee:faces-config-ifType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">If this EL expression evaluates to
+            <code>true</code>, the corresponding <code>from-outcome</code> will 
+            be the outcome taken by the enclosing <code>&lt;switch&gt;</code></p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The "from-outcome" element contains a logical outcome
+            string returned by the execution of an application
+            action method selected via an "actionRef" property
+            (or a literal value specified by an "action" property)
+            of a UICommand component.  If specified, this rule
+            will be relevant only if the outcome value matches
+            this element's value.  If not specified, this rule
+            will be relevant if the outcome value is non-null
+            or, if the "if" element is present, will be relevant
+            for any outcome value, with the assumption that the
+            condition specified in the "if" element ultimately
+            determines if this rule is a match.</p>
+            
+            <p class="changed_added_2_2">If used in a faces flow, this element
+            represents the node id to which control will be passed.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID">
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-returnType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a return node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain exactly one <code>&lt;from-outcome&gt;</code> element.</p>
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">This element
+            represents the node id to which control will be passed.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow-return.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-callType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Define a call node in a flow graph.</p>
+        
+        <div class="changed_added_2_2">
+        
+        <p>This element must contain exactly one <code>&lt;flow-reference&gt;</code> element, 
+        which must contain exactly one <code>&lt;flow-id&gt;</code> element.</p>
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="flow-reference"
+                   type="jakartaee:faces-config-flow-definition-flow-call-flow-referenceType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The flow id of the called flow.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="outbound-parameter"
+                   type="jakartaee:faces-config-flow-definition-flow-call-outbound-parameterType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">A parameter to pass when calling the flow
+            identified in the "flow-reference" element that is a sibling of this element.<p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          <p class="changed_added_2_2">The id of this flow-return.</p>
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-flow-referenceType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Identifiy the called flow.</p>
+        
+        <div class="changed_added_2_2">
+        
+        </div>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="flow-document-id"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The document id of the called flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="flow-id"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The id of the called flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-initializerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is entered.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-finalizerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A <code>MethodExpression</code> that will be invoked when the flow is exited.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-el-expressionType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-inbound-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A named parameter whose value will be populated
+        with a correspondingly named parameter within an "outbound-parameter" element.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "name" element within an "inbound-parameter"
+            element declares the name of this parameter
+            to be passed into a flow.  There must be 
+            a sibling "value" element in the same parent as this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "inbound-parameter"
+            must be an EL Expression whose value will be set with the correspondingly
+            named "outbound-parameter" when this flow is entered, if such a 
+            parameter exists.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-flow-definition-flow-call-outbound-parameterType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">A named parameter whose value will be 
+        passed to a correspondingly named parameter within an "inbound-parameter" element
+        on the target flow.<p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "name" element within an "outbound-parameter" element 
+            declares the name of this parameter to be passed out of a flow.  There must be 
+            a sibling "value" element in the same parent as this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value"
+                   type="jakartaee:faces-config-flow-definition-parameter-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2"> The "value" element within an "outbound-parameter"
+            must be a literal string or an EL Expression whose "get" will be called when the "flow-call"
+            containing this element is traversed to go to a new flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-managed-bean-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for managed-bean.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-managed-bean-scopeOrNoneType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        
+        <p> Defines the legal values for the <managed-bean-scope>
+        element's body content, which includes all of the scopes
+        normally used in a web application, plus the "none" value
+        indicating that a created bean should not be stored into
+        any scope.  Alternatively, an EL expression may be used
+        as the value of this element.  The result of evaluating this
+        expression must by of type java.util.Map.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:pattern value="view|request|session|application|none|#\{.*\}"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-managed-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "managed-property" element represents an individual
+        property of a managed bean that will be configured to the
+        specified value (or value set) if the corresponding
+        managed bean is automatically created.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="property-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-name" element represents the JavaBeans
+            property name under which the corresponding value may
+            be stored.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property-class"
+                   type="jakartaee:java-typeType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-class" element represents the Java type
+            of the value associated with this property name.
+            If not specified, it can be inferred from existing
+            classes; however, this element should be specified
+            if the configuration file is going to be the source
+            for generating the corresponding classes.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="map-entries"
+                     type="jakartaee:faces-config-map-entriesType"/>
+        <xsd:element name="null-value"
+                     type="jakartaee:faces-config-null-valueType"/>
+        <xsd:element name="value"
+                     type="jakartaee:faces-config-valueType"/>
+        <xsd:element name="list-entries"
+                     type="jakartaee:faces-config-list-entriesType"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-map-entryType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "map-entry" element reprsents a single key-entry pair
+        that will be added to the computed value of a managed
+        property of type java.util.Map.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="key"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "key" element is the String representation of a
+            map key that will be stored in a managed property of
+            type java.util.Map.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:element name="null-value"
+                     type="jakartaee:faces-config-null-valueType"/>
+        <xsd:element name="value"
+                     type="jakartaee:faces-config-valueType"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-map-entriesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "map-entries' element represents a set of key-entry pairs
+        that will be added to the computed value of a managed property
+        of type java.util.Map.  In addition, the Java class types
+        of the key and entry values may be optionally declared.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="key-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "key-class" element defines the Java type to which
+            each "key" element in a set of "map-entry" elements
+            will be converted to.  If omitted, "java.lang.String"
+            is assumed.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="value-class"
+                   type="jakartaee:faces-config-value-classType"
+                   minOccurs="0"/>
+      <xsd:element name="map-entry"
+                   type="jakartaee:faces-config-map-entryType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-caseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> <span class="changed_modified_2_2">The</span>
+        "navigation-case" element describes a particular
+        combination of conditions that must match for this case to
+        be executed, and the view id of the component tree that
+        should be selected next.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="from-action"
+                   type="jakartaee:faces-config-from-actionType"
+                   minOccurs="0"/>
+      <xsd:element name="from-outcome"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p>The "from-outcome" element contains a logical outcome
+            string returned by the execution of an application
+            action method selected via an "actionRef" property
+            (or a literal value specified by an "action" property)
+            of a UICommand component.  If specified, this rule
+            will be relevant only if the outcome value matches
+            this element's value.  If not specified, this rule
+            will be relevant if the outcome value is non-null
+            or, if the "if" element is present, will be relevant
+            for any outcome value, with the assumption that the
+            condition specified in the "if" element ultimately
+            determines if this rule is a match.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="if"
+                   type="jakartaee:faces-config-ifType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Please see section JSF.7.4.2 for the specification of this element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="to-view-id"
+                   type="jakartaee:faces-config-valueType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p><span class="changed_modified_2_2">The "to-view-id" element 
+            contains the view identifier (<span class="changed_added_2_2">or 
+            flow node id, or flow id</span>)
+            of the next view (<span class="changed_added_2_2">or flow node or 
+            flow</span>) that should be displayed if this
+            navigation rule is matched. If the contents is a
+            value expression, it should be resolved by the
+            navigation handler to obtain the view (
+            <span class="changed_added_2_2">or flow node or flow</span>) 
+            identifier.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="to-flow-document-id"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p class="changed_added_2_2">The document id of the called flow.
+            If this element appears in a &lt;navigation-case&gt; nested within 
+            a &lt;flow-definition&gt;, it must be ignored because navigation
+            cases within flows may only navigate among the view nodes of that 
+            flow.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="redirect"
+                   type="jakartaee:faces-config-redirectType"
+                   minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-ruleType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "navigation-rule" element represents an individual
+        decision rule that will be utilized by the default
+        NavigationHandler implementation to make decisions on
+        what view should be displayed next, based on the
+        view id being processed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="from-view-id"
+                   type="jakartaee:faces-config-from-view-idType"/>
+      <xsd:element name="navigation-case"
+                   type="jakartaee:faces-config-navigation-caseType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="navigation-rule-extension"
+                   type="jakartaee:faces-config-navigation-rule-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-navigation-rule-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for navigation-rule.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-null-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "null-value" element indicates that the managed
+        property in which we are nested will be explicitly
+        set to null if our managed bean is automatically
+        created.  This is different from omitting the managed
+        property element entirely, which will cause no
+        property setter to be called for this property.</p>
+        
+        <p>The "null-value" element can only be used when the
+        associated "property-class" identifies a Java class,
+        not a Java primitive.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-propertyType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "property" element represents a JavaBean property of the
+        Java class represented by our parent element.</p>
+        
+        <p>Property names must be unique within the scope of the Java
+        class that is represented by the parent element, and must
+        correspond to property names that will be recognized when
+        performing introspection against that class via
+        java.beans.Introspector.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="property-name"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-name" element represents the JavaBeans
+            property name under which the corresponding value
+            may be stored.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property-class"
+                   type="jakartaee:java-typeType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "property-class" element represents the Java type
+            of the value associated with this property name.
+            If not specified, it can be inferred from existing
+            classes; however, this element should be specified if
+            the configuration file is going to be the source for
+            generating the corresponding classes.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="default-value"
+                   type="jakartaee:faces-config-default-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="suggested-value"
+                   type="jakartaee:faces-config-suggested-valueType"
+                   minOccurs="0"/>
+      <xsd:element name="property-extension"
+                   type="jakartaee:faces-config-property-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-protected-viewsType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p class="changed_added_2_2">Any view that matches any of the
+        url-patterns in this element may only be reached from another Jakarta Server 
+        Faces view in the same web application. Because the runtime is aware of
+        which views are protected, any navigation from an unprotected
+        view to a protected view is automatically subject to
+        protection.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="url-pattern"
+                   type="jakartaee:url-patternType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-property-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for property.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirectType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "redirect" element indicates that navigation to the
+        specified "to-view-id" should be accomplished by
+        performing an HTTP redirect rather than the usual
+        ViewHandler mechanisms.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="redirect-param"
+                   type="jakartaee:faces-config-redirect-redirectParamType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+    <xsd:attribute name="include-view-params"
+                   type="xsd:boolean"
+                   use="optional"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirect-viewParamType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This element was introduced due to a specification
+        error, and is now deprecated.  The correct name for
+        this element is "redirect-param" and its meaning is
+        documented therein.  The "view-param" element is
+        maintained to preserve backwards compatibility.
+        Implementations must treat this element the same as
+        "redirect-param".</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:string"/>
+      <xsd:element name="value"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-redirect-redirectParamType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "redirect-param" element, only valid within
+        a "redirect" element, contains child "name"
+        and "value" elements that must be included in the
+        redirect url when the redirect is performed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:string"/>
+      <xsd:element name="value"
+                   type="jakartaee:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-referenced-beanType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "referenced-bean" element represents at design time the
+        promise that a Java object of the specified type will exist at
+        runtime in some scope, under the specified key.  This can be
+        used by design time tools to construct user interface dialogs
+        based on the properties of the specified class.  The presence
+        or absence of a referenced bean element has no impact on the
+        JavaServer Faces runtime environment inside a web application.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="referenced-bean-name"
+                   type="jakartaee:java-identifierType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "referenced-bean-name" element represents the
+            attribute name under which the corresponding
+            referenced bean may be assumed to be stored, in one
+            of 'request', 'session', 'view', 'application'
+            or a custom scope.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="referenced-bean-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "referenced-bean-class" element represents the
+            fully qualified class name of the Java class
+            (either abstract or concrete) or Java interface
+            implemented by the corresponding referenced bean.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-render-kitType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "render-kit" element represents a concrete RenderKit
+        implementation that should be registered under the specified
+        render-kit-id.  If no render-kit-id is specified, the
+        identifier of the default RenderKit
+        (RenderKitFactory.DEFAULT_RENDER_KIT) is assumed.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="render-kit-id"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-id" element represents an identifier
+            for the RenderKit represented by the parent
+            "render-kit" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="render-kit-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "render-kit-class" element represents the fully
+            qualified class name of a concrete RenderKit
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer"
+                   type="jakartaee:faces-config-rendererType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="client-behavior-renderer"
+                   type="jakartaee:faces-config-client-behavior-rendererType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="render-kit-extension"
+                   type="jakartaee:faces-config-render-kit-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-client-behavior-rendererType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "client-behavior-renderer" element represents a concrete
+        ClientBehaviorRenderer implementation class that should be
+        registered under the specified behavior renderer type identifier,
+        in the RenderKit associated with the parent "render-kit"
+        element.  Client Behavior renderer type must be unique within the RenderKit
+        associated with the parent "render-kit" element.</p>
+        
+        <p>Nested "attribute" elements identify generic component
+        attributes that are recognized by this renderer.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="client-behavior-renderer-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "client-behavior-renderer-type" element represents a renderer type
+            identifier for the Client Behavior Renderer represented by the parent
+            "client-behavior-renderer" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="client-behavior-renderer-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "client-behavior-renderer-class" element represents the fully
+            qualified class name of a concrete Client Behavior Renderer
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-rendererType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "renderer" element represents a concrete Renderer
+        implementation class that should be registered under the
+        specified component family and renderer type identifiers,
+        in the RenderKit associated with the parent "render-kit"
+        element.  Combinations of component family and
+        renderer type must be unique within the RenderKit
+        associated with the parent "render-kit" element.</p>
+        
+        <p>Nested "attribute" elements identify generic component
+        attributes that are recognized by this renderer.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="component-family"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "component-family" element represents the
+            component family for which the Renderer represented
+            by the parent "renderer" element will be used.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer-type"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "renderer-type" element represents a renderer type
+            identifier for the Renderer represented by the parent
+            "renderer" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="renderer-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "renderer-class" element represents the fully
+            qualified class name of a concrete Renderer
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="facet"
+                   type="jakartaee:faces-config-facetType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="renderer-extension"
+                   type="jakartaee:faces-config-renderer-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-renderer-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for renderer.  It may contain implementation
+        specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-render-kit-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for render-kit.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-suggested-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "suggested-value" contains the value for the property or
+        attribute in which this element resides.  This value is
+        advisory only and is intended for tools to use when
+        populating pallettes.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-supported-localeType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "supported-locale" element allows authors to declare
+        which locales are supported in this application instance.</p>
+        
+        <p class="modified_added_2_3">
+        To facilitate BCP 47 this element first needs to be parsed by the
+        Locale.forLanguageTag method. If it does not return a Locale with
+        a language the old specification below needs to take effect.
+        </p>
+        
+        <p>It must be specified as :language:[_:country:[_:variant:]]
+        without the colons, for example "ja_JP_SJIS".  The
+        separators between the segments may be '-' or '_'.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:extension base="jakartaee:faces-config-localeType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-behaviorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "behavior" element represents a concrete Behavior
+        implementation class that should be registered under the
+        specified behavior identifier.  Behavior identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Behavior.  Nested "property"
+        elements identify JavaBeans properties of the Behavior
+        implementation class that may be configured to affect the
+        operation of the Behavior.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="behavior-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "behavior-id" element represents the identifier
+            under which the corresponding Behavior class should
+            be registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="behavior-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "behavior-class" element represents the fully
+            qualified class name of a concrete Behavior
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Behavior.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Behavior implementation class
+            that may be configured to affect the operation of
+            the Behavior.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="behavior-extension"
+                   type="jakartaee:faces-config-behavior-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-behavior-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for behavior.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "validator" element represents a concrete Validator
+        implementation class that should be registered under the
+        specified validator identifier.  Validator identifiers must
+        be unique within the entire web application.</p>
+        
+        <p>Nested "attribute" elements identify generic attributes that
+        may be configured on the corresponding UIComponent in order
+        to affect the operation of the Validator.  Nested "property"
+        elements identify JavaBeans properties of the Validator
+        implementation class that may be configured to affect the
+        operation of the Validator.  "attribute" and "property"
+        elements are intended to allow component developers to
+        more completely describe their components to tools and users.
+        These elements have no required runtime semantics.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="validator-id"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-id" element represents the identifier
+            under which the corresponding Validator class should
+            be registered.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "validator-class" element represents the fully
+            qualified class name of a concrete Validator
+            implementation class.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="attribute"
+                   type="jakartaee:faces-config-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "attribute" elements identify generic
+            attributes that may be configured on the
+            corresponding UIComponent in order to affect the
+            operation of the Validator.  This attribute is
+            primarily for design-time tools and is not
+            specified to have any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="property"
+                   type="jakartaee:faces-config-propertyType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> Nested "property" elements identify JavaBeans
+            properties of the Validator implementation class
+            that may be configured to affect the operation of
+            the Validator.  This attribute is primarily for
+            design-time tools and is not specified to have
+            any meaning at runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator-extension"
+                   type="jakartaee:faces-config-validator-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-validator-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> Extension element for validator.  It may contain
+        implementation specific content.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any minOccurs="0"
+               maxOccurs="unbounded"
+               namespace="##any"
+               processContents="lax"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "value" element is the String representation of
+        a literal value to which a scalar managed property
+        will be set, or a value binding expression ("#{...}")
+        that will be used to calculate the required value.
+        It will be converted as specified for the actual
+        property type.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:union memberTypes="jakartaee:faces-config-el-expressionType xsd:string"/>
+  </xsd:simpleType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-value-classType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "value-class" element defines the Java type to which each
+        "value" element's value will be converted to, prior to adding
+        it to the "list-entries" list for a managed property that is
+        a java.util.List, or a "map-entries" map for a managed
+        property that is a java.util.Map.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:fully-qualified-classType">
+        <xsd:attribute name="id"
+                       type="xsd:ID"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-list-entriesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The "list-entries" element represents a set of initialization
+        elements for a managed property that is a java.util.List or an
+        array.  In the former case, the "value-class" element can
+        optionally be used to declare the Java type to which each
+        value should be converted before adding it to the Collection.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="value-class"
+                   type="jakartaee:faces-config-value-classType"
+                   minOccurs="0"/>
+      <xsd:choice minOccurs="0"
+                  maxOccurs="unbounded">
+        <xsd:element name="null-value"
+                     type="jakartaee:faces-config-null-valueType"/>
+        <xsd:element name="value"
+                     type="jakartaee:faces-config-valueType"/>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="faces-config-system-event-listenerType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> The presence of this element within the "application" element in
+        an application configuration resource file indicates the
+        developer wants to add an SystemEventListener to this
+        application instance.  Elements nested within this element allow
+        selecting the kinds of events that will be delivered to the
+        listener instance, and allow selecting the kinds of classes that
+        can be the source of events that are delivered to the listener
+        instance.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="system-event-listener-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "system-event-listener-class" element contains
+            the fully qualified class name of the concrete
+            SystemEventListener implementation class that will be
+            called when events of the type specified by the
+            "system-event-class" are sent by the runtime.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="system-event-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "system-event-class" element contains the fully
+            qualified class name of the SystemEvent subclass for
+            which events will be delivered to the class whose fully
+            qualified class name is given by the
+            "system-event-listener-class" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="source-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            <p> The "source-class" element, if present, contains the
+            fully qualified class name of the class that will be the
+            source for the event to be delivered to the class whose
+            fully qualified class name is given by the
+            "system-event-listener-class" element.</p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="faces-config-versionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        <p> This type contains the recognized versions of
+        faces-config supported.</p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="3.0"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/web-fragment_5_0.xsd
+++ b/web/src/main/resources/schema/web-fragment_5_0.xsd
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="5.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the Servlet 5.0 deployment descriptor.
+      The deployment descriptor must be named "META-INF/web-fragment.xml"
+      in the web fragment's jar file.  All Servlet deployment descriptors
+      must indicate the web application schema by using the Jakarta EE
+      namespace:
+      
+      https://jakarta.ee/xml/ns/jakartaee
+      
+      and by indicating the version of the schema by
+      using the version element as shown below:
+      
+      <web-fragment xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="5.0">
+      ...
+      </web-fragment>
+      
+      The instance documents may indicate the published version of
+      the schema using the xsi:schemaLocation attribute for Jakarta EE
+      namespace with the following location:
+      
+      https://jakarta.ee/xml/ns/jakartaee/web-fragment_5_0.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      The following conventions apply to all Jakarta EE
+      deployment descriptor elements unless indicated otherwise.
+      
+      - In elements that specify a pathname to a file within the
+      same JAR file, relative filenames (i.e., those not
+      starting with "/") are considered relative to the root of
+      the JAR file's namespace.  Absolute filenames (i.e., those
+      starting with "/") also specify names in the root of the
+      JAR file's namespace.  In general, relative names are
+      preferred.  The exception is .war files where absolute
+      names are preferred for consistency with the Servlet API.
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="web-common_5_0.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="web-fragment"
+               type="jakartaee:web-fragmentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The web-fragment element is the root of the deployment
+        descriptor for a web fragment.  Note that the sub-elements
+        of this element can be in the arbitrary order. Because of
+        that, the multiplicity of the elements of distributable,
+        session-config, welcome-file-list, jsp-config, login-config,
+        and locale-encoding-mapping-list was changed from "?" to "*"
+        in this schema.  However, the deployment descriptor instance
+        file must not contain multiple elements of session-config,
+        jsp-config, and login-config. When there are multiple elements of
+        welcome-file-list or locale-encoding-mapping-list, the container
+        must concatenate the element contents.  The multiple occurence
+        of the element distributable is redundant and the container
+        treats that case exactly in the same way when there is only
+        one distributable.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="web-common-servlet-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The servlet element contains the name of a servlet.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet"/>
+      <xsd:field xpath="jakartaee:servlet-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-filter-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The filter element contains the name of a filter.
+          The name must be unique within the web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:filter"/>
+      <xsd:field xpath="jakartaee:filter-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-local-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-local-ref-name element contains the name of an 
+          enterprise bean reference. The enterprise bean reference
+          is an entry in the web application's environment and is relative
+          to the java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-local-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-ejb-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The ejb-ref-name element contains the name of an  
+          enterprise bean reference. The enterprise bean reference 
+          is an entry in the web application's environment and is relative 
+          to the java:comp/env context.  The name must be unique within
+          the web application.
+          
+          It is recommended that name is prefixed with "ejb/".
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:ejb-ref"/>
+      <xsd:field xpath="jakartaee:ejb-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-resource-env-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The resource-env-ref-name element specifies the name of
+          a resource environment reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-env-ref"/>
+      <xsd:field xpath="jakartaee:resource-env-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-message-destination-ref-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The message-destination-ref-name element specifies the name of
+          a message destination reference; its value is the
+          environment entry name used in the web application code.
+          The name is a JNDI name relative to the java:comp/env
+          context and must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:message-destination-ref"/>
+      <xsd:field xpath="jakartaee:message-destination-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-res-ref-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The res-ref-name element specifies the name of a
+          resource manager connection factory reference.  The name
+          is a JNDI name relative to the java:comp/env context.
+          The name must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:resource-ref"/>
+      <xsd:field xpath="jakartaee:res-ref-name"/>
+    </xsd:unique>
+    <xsd:unique name="web-common-env-entry-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The env-entry-name element contains the name of a web
+          application's environment entry.  The name is a JNDI
+          name relative to the java:comp/env context.  The name
+          must be unique within a web application.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:env-entry"/>
+      <xsd:field xpath="jakartaee:env-entry-name"/>
+    </xsd:unique>
+    <xsd:key name="web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          A role-name-key is specified to allow the references
+          from the security-role-refs.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:security-role"/>
+      <xsd:field xpath="jakartaee:role-name"/>
+    </xsd:key>
+    <xsd:keyref name="web-common-role-name-references"
+                refer="jakartaee:web-common-role-name-key">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The keyref indicates the references from
+          security-role-ref to a specified role-name.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:servlet/jakartaee:security-role-ref"/>
+      <xsd:field xpath="jakartaee:role-link"/>
+    </xsd:keyref>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="web-fragmentType">
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"/>
+      <xsd:group ref="jakartaee:web-commonType"/>
+      <xsd:element name="ordering"
+                   type="jakartaee:orderingType"/>
+    </xsd:choice>
+    <xsd:attributeGroup ref="jakartaee:web-common-attributes"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Please see section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="after"
+                   type="jakartaee:ordering-orderingType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="before"
+                   type="jakartaee:ordering-orderingType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="ordering-orderingType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This element contains a sequence of "name" elements, each of
+        which
+        refers to an application configuration resource by the "name"
+        declared on its web.xml fragment.  This element can also contain
+        a single "others" element which specifies that this document
+        comes
+        before or after other documents within the application.
+        See section 8.2.2 of the specification for details.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="others"
+                   type="jakartaee:ordering-othersType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/web-jsptaglibrary_3_0.xsd
+++ b/web/src/main/resources/schema/web-jsptaglibrary_3_0.xsd
@@ -1,0 +1,1109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            elementFormDefault="qualified"
+            attributeFormDefault="unqualified"
+            version="3.0">
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      This is the XML Schema for the JSP Taglibrary 
+      descriptor.  All Taglibrary descriptors must 
+      indicate the tag library schema by using the Taglibrary 
+      namespace: 
+      
+      https://jakarta.ee/xml/ns/jakartaee 
+      
+      and by indicating the version of the schema by 
+      using the version element as shown below: 
+      
+      <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="..."
+      version="3.0">
+      ...
+      </taglib>
+      
+      The instance documents may indicate the published 
+      version of the schema using xsi:schemaLocation attribute 
+      for Jakarta EE namespace with the following location: 
+      
+      https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="taglib"
+               type="jakartaee:tldTaglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The taglib tag is the document root.
+        The definition of taglib is provided
+        by the tldTaglibType. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:unique name="tag-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The taglib element contains, among other things, tag and 
+          tag-file elements.
+          The name subelements of these elements must each be unique.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:tag|jakartaee:tag-file"/>
+      <xsd:field xpath="jakartaee:name"/>
+    </xsd:unique>
+    <xsd:unique name="function-name-uniqueness">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          The taglib element contains function elements.
+          The name subelements of these elements must each be unique.
+          
+        </xsd:documentation>
+      </xsd:annotation>
+      <xsd:selector xpath="jakartaee:function"/>
+      <xsd:field xpath="jakartaee:name"/>
+    </xsd:unique>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="body-contentType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Specifies the type of body that is valid for a tag.
+        This value is used by the JSP container to validate 
+        that a tag invocation has the correct body syntax and 
+        by page composition tools to assist the page author 
+        in providing a valid tag body.
+        		    
+        There are currently four values specified:
+        
+        tagdependent    The body of the tag is interpreted by the tag
+        		implementation itself, and is most likely 
+        		in a different "language", e.g embedded SQL 
+        		statements.
+        
+        JSP             The body of the tag contains nested JSP 
+        		syntax.
+        
+        empty           The body must be empty
+        
+        scriptless      The body accepts only template text, EL 
+        		Expressions, and JSP action elements.  No 
+        		scripting elements are allowed.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="tagdependent"/>
+        <xsd:enumeration value="JSP"/>
+        <xsd:enumeration value="empty"/>
+        <xsd:enumeration value="scriptless"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-canonical-nameType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines the canonical name of a tag or attribute being
+        defined.
+        
+        The name must conform to the lexical rules for an NMTOKEN.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:xsdNMTOKENType"/>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="validatorType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        A validator that can be used to validate
+        the conformance of a JSP page to using this tag library is
+        defined by a validatorType.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="validator-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the TagLibraryValidator class that can be used
+            to validate the conformance of a JSP page to using this
+            tag library.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="init-param"
+                   type="jakartaee:param-valueType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The init-param element contains a name/value pair as an
+            initialization param. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tagType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The tag defines a unique tag in this tag library.  It has one
+        attribute, id.
+        
+        The tag element may have several subelements defining:
+        
+        description       Optional tag-specific information
+        
+        display-name      A short name that is intended to be 
+        		  displayed by tools
+        
+        icon              Optional icon element that can be used 
+        		  by tools
+        
+        name              The unique action name
+        
+        tag-class         The tag handler class implementing
+        		  jakarta.servlet.jsp.tagext.JspTag
+        
+        tei-class         An optional subclass of
+        		  jakarta.servlet.jsp.tagext.TagExtraInfo
+        
+        body-content      The body content type
+        
+        variable          Optional scripting variable information
+        
+        attribute         All attributes of this action that are
+        		  evaluated prior to invocation.
+        
+        dynamic-attributes Whether this tag supports additional 
+        		   attributes with dynamic names.  If 
+        		   true, the tag-class must implement the 
+        		   jakarta.servlet.jsp.tagext.DynamicAttributes
+        		   interface.  Defaults to false.
+        
+        example           Optional informal description of an 
+        		  example of a use of this tag
+        
+        tag-extension     Zero or more extensions that provide extra
+        		  information about this tag, for tool 
+        		  consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:tld-canonical-nameType"/>
+      <xsd:element name="tag-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the subclass of jakarta.serlvet.jsp.tagext.JspTag
+            that implements the request time semantics for 
+            this tag. (required)
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tei-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines the subclass of jakarta.servlet.jsp.tagext.TagExtraInfo
+            for this tag. (optional)
+            
+            If this is not given, the class is not consulted at
+            translation time.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="body-content"
+                   type="jakartaee:body-contentType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Specifies the format for the body of this tag.
+            The default in JSP 1.2 was "JSP" but because this 
+            is an invalid setting for simple tag handlers, there 
+            is no longer a default in JSP 2.0.  A reasonable 
+            default for simple tag handlers is "scriptless" if 
+            the tag can have a body.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="variable"
+                   type="jakartaee:variableType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="attribute"
+                   type="jakartaee:tld-attributeType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="dynamic-attributes"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0"/>
+      <xsd:element name="example"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The example element contains an informal description
+            of an example of the use of a tag.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Tag extensions are for tool use only and must not affect
+            the behavior of a container.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tagFileType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines an action in this tag library that is implemented
+        as a .tag file.
+        
+        The tag-file element has two required subelements:
+        
+        description       Optional tag-specific information
+        
+        display-name      A short name that is intended to be 
+        		  displayed by tools
+        
+        icon              Optional icon element that can be used 
+        		  by tools
+        
+        name              The unique action name
+        
+        path              Where to find the .tag file implementing this
+        		  action, relative to the root of the web
+        		  application or the root of the JAR file for a
+        		  tag library packaged in a JAR.  This must
+        		  begin with /WEB-INF/tags if the .tag file
+        		  resides in the WAR, or /META-INF/tags if the
+        		  .tag file resides in a JAR.
+        
+        example           Optional informal description of an 
+        		  example of a use of this tag
+        
+        tag-extension     Zero or more extensions that provide extra
+        		  information about this tag, for tool 
+        		  consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:tld-canonical-nameType"/>
+      <xsd:element name="path"
+                   type="jakartaee:pathType"/>
+      <xsd:element name="example"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The example element contains an informal description
+            of an example of the use of a tag.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="tag-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Tag extensions are for tool use only and must not affect
+            the behavior of a container.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="functionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The function element is used to provide information on each
+        function in the tag library that is to be exposed to the EL.
+        
+        The function element may have several subelements defining:
+        
+        description         Optional tag-specific information
+        
+        display-name        A short name that is intended to be 
+        		    displayed by tools
+        
+        icon                Optional icon element that can be used 
+        		    by tools
+        
+        name                A unique name for this function
+        
+        function-class      Provides the name of the Java class that 
+        		    implements the function
+        
+        function-signature  Provides the signature, as in the Java 
+        		    Language Specification, of the Java 
+        		    method that is to be used to implement 
+        		    the function.
+        
+        example             Optional informal description of an 
+        		    example of a use of this function
+        
+        function-extension  Zero or more extensions that provide extra
+        		    information about this function, for tool 
+        		    consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="name"
+                   type="jakartaee:tld-canonical-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            A unique name for this function.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="function-class"
+                   type="jakartaee:fully-qualified-classType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Provides the fully-qualified class name of the Java
+            class containing the static method that implements 
+            the function.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="function-signature"
+                   type="jakartaee:string">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Provides the signature, of the static Java method that is
+            to be used to implement the function.  The syntax of the
+            function-signature element is as follows:
+            
+            	FunctionSignature ::= ReturnType S MethodName S?
+            			      '(' S? Parameters? S? ')'
+            
+            ReturnType        ::= Type
+            
+            	MethodName        ::= Identifier
+            
+            	Parameters        ::=   Parameter
+            			      | ( Parameter S? ',' S? Parameters )
+            
+            Parameter         ::= Type
+            
+            	Where:
+            
+            	    * Type is a basic type or a fully qualified
+            	      Java class name (including package name),
+            	      as per the 'Type' production in the Java 
+            	      Language Specification, Second Edition, 
+            	      Chapter 18.
+            
+            * Identifier is a Java identifier, as per
+            	      the 'Identifier' production in the Java 
+            	      Language Specification, Second
+            	      Edition, Chapter 18.
+            
+            Example: 
+            
+            java.lang.String nickName( java.lang.String, int )
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="example"
+                   type="jakartaee:xsdStringType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The example element contains an informal description
+            of an example of the use of this function.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="function-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Function extensions are for tool use only and must not 
+            affect the behavior of a container.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tldTaglibType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The taglib tag is the document root, it defines:
+        
+        description     a simple string describing the "use" of this
+        		taglib, should be user discernable
+        
+        display-name    the display-name element contains a 
+        		short name that is intended to be displayed 
+        		by tools
+        
+        icon            optional icon that can be used by tools
+        
+        tlib-version    the version of the tag library implementation 
+        
+        short-name      a simple default short name that could be 
+        		used by a JSP authoring tool to create 
+        		names with a mnemonic value; for example, 
+        		the it may be used as the prefered prefix 
+        		value in taglib directives
+        
+        uri             a uri uniquely identifying this taglib
+        
+        validator       optional TagLibraryValidator information
+        
+        listener        optional event listener specification
+        
+        tag             tags in this tag library
+        
+        tag-file        tag files in this tag library
+        
+        function        zero or more EL functions defined in this 
+        		tag library
+        
+        taglib-extension zero or more extensions that provide extra
+        		information about this taglib, for tool 
+        		consumption
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:group ref="jakartaee:descriptionGroup"/>
+      <xsd:element name="tlib-version"
+                   type="jakartaee:dewey-versionType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Describes this version (number) of the taglibrary.
+            It is described as a dewey decimal. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="short-name"
+                   type="jakartaee:tld-canonical-nameType">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a simple default name that could be used by
+            a JSP authoring tool to create names with a 
+            mnemonicvalue; for example, it may be used as the 
+            preferred prefix value in taglib directives.  Do 
+            not use white space, and do not start with digits 
+            or underscore. 
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="uri"
+                   type="jakartaee:xsdAnyURIType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines a public URI that uniquely identifies this
+            version of the taglibrary.  Leave it empty if it
+            does not apply.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="validator"
+                   type="jakartaee:validatorType"
+                   minOccurs="0">
+      </xsd:element>
+      <xsd:element name="listener"
+                   type="jakartaee:listenerType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+      </xsd:element>
+      <xsd:element name="tag"
+                   type="jakartaee:tagType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="tag-file"
+                   type="jakartaee:tagFileType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="function"
+                   type="jakartaee:functionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="taglib-extension"
+                   type="jakartaee:tld-extensionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Taglib extensions are for tool use only and must not 
+            affect the behavior of a container.  
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="version"
+                   type="jakartaee:dewey-versionType"
+                   fixed="3.0"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+
+          Describes the JSP version (number) this taglibrary
+          requires in order to function (dewey decimal)
+          
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="variableType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The variableType provides information on the scripting
+        variables defined by using this tag.  It is a (translation 
+        time) error for a tag that has one or more variable 
+        subelements to have a TagExtraInfo class that returns a 
+        non-null value from a call to getVariableInfo().
+        
+        The subelements of variableType are of the form:
+        
+        description              Optional description of this 
+        			 variable
+        
+        name-given               The variable name as a constant
+        
+        name-from-attribute      The name of an attribute whose 
+        			 (translation time) value will 
+        			 give the name of the
+        			 variable.  One of name-given or
+        			 name-from-attribute is required.
+        
+        variable-class           Name of the class of the variable.
+        			 java.lang.String is default.
+        
+        declare                  Whether the variable is declared 
+        			 or not.  True is the default.
+        
+        scope                    The scope of the scripting varaible
+        			 defined.  NESTED is default.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:choice>
+        <xsd:element name="name-given"
+                     type="jakartaee:java-identifierType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The name for the scripting variable.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+        <xsd:element name="name-from-attribute"
+                     type="jakartaee:java-identifierType">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              The name of an attribute whose
+              (translation-time) value will give the name of 
+              the variable.
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+      <xsd:element name="variable-class"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The optional name of the class for the scripting
+            variable.  The default is java.lang.String.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="declare"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Whether the scripting variable is to be defined
+            or not.  See TagExtraInfo for details.  This 
+            element is optional and "true" is the default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="scope"
+                   type="jakartaee:variable-scopeType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The element is optional and "NESTED" is the default.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="variable-scopeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        This type defines scope of the scripting variable.  See
+        TagExtraInfo for details.  The allowed values are, 
+        "NESTED", "AT_BEGIN" and "AT_END".
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:simpleContent>
+      <xsd:restriction base="jakartaee:string">
+        <xsd:enumeration value="NESTED"/>
+        <xsd:enumeration value="AT_BEGIN"/>
+        <xsd:enumeration value="AT_END"/>
+      </xsd:restriction>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-attributeType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The attribute element defines an attribute for the nesting
+        tag.  The attribute element may have several subelements 
+        defining: 
+        
+        description     a description of the attribute
+        
+        name            the name of the attribute 
+        
+        required        whether the attribute is required or 
+        		optional 
+        
+        rtexprvalue     whether the attribute is a runtime attribute 
+        
+        type            the type of the attributes 
+        
+        fragment        whether this attribute is a fragment
+        
+        deferred-value  present if this attribute is to be parsed as a
+        jakarta.el.ValueExpression
+        
+        deferred-method present if this attribute is to be parsed as a
+        jakarta.el.MethodExpression
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="description"
+                   type="jakartaee:descriptionType"
+                   minOccurs="0"
+                   maxOccurs="unbounded"/>
+      <xsd:element name="name"
+                   type="jakartaee:java-identifierType"/>
+      <xsd:element name="required"
+                   type="jakartaee:generic-booleanType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Defines if the nesting attribute is required or
+            optional.
+            
+            If not present then the default is "false", i.e 
+            the attribute is optional.
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:choice>
+        <xsd:sequence>
+          <xsd:sequence minOccurs="0">
+            <xsd:element name="rtexprvalue"
+                         type="jakartaee:generic-booleanType">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  	  Defines if the nesting attribute can have scriptlet
+                  	  expressions as a value, i.e the value of the
+                  	  attribute may be dynamically calculated at request
+                  	  time, as opposed to a static value determined at
+                  	  translation time.
+                  	  If not present then the default is "false", i.e the
+                  	  attribute has a static value
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="type"
+                         type="jakartaee:fully-qualified-classType"
+                         minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  	  Defines the Java type of the attributes value.  
+                  If this element is omitted, the expected type is 
+                  assumed to be "java.lang.Object".  
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:choice>
+            <xsd:element name="deferred-value"
+                         type="jakartaee:tld-deferred-valueType"
+                         minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Present if the value for this attribute is to be 
+                  passed to the tag handler as a 
+                  jakarta.el.ValueExpression. This allows for deferred 
+                  evaluation of EL expressions. An optional subelement 
+                  will contain the expected type that the value will 
+                  be coerced to after evaluation of the expression.
+                  The type defaults to Object if one is not provided.
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="deferred-method"
+                         type="jakartaee:tld-deferred-methodType"
+                         minOccurs="0">
+              <xsd:annotation>
+                <xsd:documentation>
+
+                  Present if the value for this attribute is to be 
+                  passed to the tag handler as a 
+                  jakarta.el.MethodExpression. This allows for deferred 
+                  evaluation of an EL expression that identifies a 
+                  method to be invoked on an Object. An optional 
+                  subelement will contain the expected method
+                  signature. The signature defaults to "void method()" 
+                  if one is not provided.
+                  
+                </xsd:documentation>
+              </xsd:annotation>
+            </xsd:element>
+          </xsd:choice>
+        </xsd:sequence>
+        <xsd:element name="fragment"
+                     type="jakartaee:generic-booleanType"
+                     minOccurs="0">
+          <xsd:annotation>
+            <xsd:documentation>
+
+              "true" if this attribute is of type
+              jakarta.servlet.jsp.tagext.JspFragment, representing dynamic
+              content that can be re-evaluated as many times 
+              as needed by the tag handler.  If omitted or "false",
+              the default is still type="java.lang.String"
+              
+            </xsd:documentation>
+          </xsd:annotation>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-deferred-valueType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines information about how to provide the value for a
+        tag handler attribute that accepts a jakarta.el.ValueExpression.
+        
+        The deferred-value element has one optional subelement:
+        
+        type            the expected type of the attribute
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="type"
+                   type="jakartaee:fully-qualified-classType"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            The fully-qualified name of the Java type that is the 
+            expected type for this deferred expression.  If this 
+            element is omitted, the expected type is assumed to be 
+            "java.lang.Object".
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-deferred-methodType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        Defines information about how to provide the value for a
+        tag handler attribute that accepts a jakarta.el.MethodExpression.
+        
+        The deferred-method element has one optional subelement:
+        
+        method-signature  Provides the signature, as in the Java
+        Language Specifies, that is expected for 
+        the method being identified by the 
+        expression.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="method-signature"
+                   type="jakartaee:string"
+                   minOccurs="0">
+        <xsd:annotation>
+          <xsd:documentation>
+
+            Provides the expected signature of the method identified 
+            by the jakarta.el.MethodExpression.
+            
+            This disambiguates overloaded methods and ensures that 
+            the return value is of the expected type.
+            
+            The syntax of the method-signature element is identical 
+            to that of the function-signature element.  See the 
+            documentation for function-signature for more details.
+            
+            The name of the method is for documentation purposes only 
+            and is ignored by the JSP container.
+            
+            Example:
+            
+            boolean validate(java.lang.String)
+            
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="tld-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The tld-extensionType is used to indicate
+        extensions to a specific TLD element.
+        
+        It is used by elements to designate an extension block
+        that is targeted to a specific extension designated by
+        a set of extension elements that are declared by a
+        namespace. The namespace identifies the extension to
+        the tool that processes the extension.
+        
+        The type of the extension-element is abstract. Therefore,
+        a concrete type must be specified by the TLD using
+        xsi:type attribute for each extension-element. 
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="extension-element"
+                   type="jakartaee:extensibleType"
+                   maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="namespace"
+                   use="required"
+                   type="xsd:anyURI"/>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="extensibleType"
+                   abstract="true">
+    <xsd:annotation>
+      <xsd:documentation>
+
+        The extensibleType is an abstract base type that is used to
+        define the type of extension-elements. Instance documents
+        must substitute a known type to define the extension by
+        using xsi:type attribute to define the actual type of
+        extension-elements.
+        
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>

--- a/web/src/main/resources/schema/web-partialresponse_3_0.xsd
+++ b/web/src/main/resources/schema/web-partialresponse_3_0.xsd
@@ -1,0 +1,403 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee"
+            attributeFormDefault="unqualified"
+            elementFormDefault="qualified"
+            targetNamespace="https://jakarta.ee/xml/ns/jakartaee"
+            version="3.0"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <xsd:include schemaLocation="jakartaee_9.xsd"/>
+
+  <xsd:annotation>
+    <xsd:documentation>
+
+      Copyright (c) 2009, 2020 Oracle and/or its affiliates. All rights reserved.
+      
+      This program and the accompanying materials are made available under the
+      terms of the Eclipse Public License v. 2.0, which is available at
+      http://www.eclipse.org/legal/epl-2.0.
+      
+      This Source Code may also be made available under the following Secondary
+      Licenses when the conditions for such availability set forth in the
+      Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+      version 2 with the GNU Classpath Exception, which is available at
+      https://www.gnu.org/software/classpath/license.html.
+      
+      SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+      
+    </xsd:documentation>
+  </xsd:annotation>
+
+  <xsd:annotation>
+    <xsd:documentation>
+      <![CDATA[
+      [
+      <p>
+      
+      The XML Schema for the Jakarta Server Faces (Version 3.0)  
+      Partial Response used in JSF Ajax frameworks.
+      
+      </p>
+      
+      ]]>
+    </xsd:documentation>
+  </xsd:annotation>
+
+
+<!-- **************************************************** -->
+
+  <xsd:element name="partial-response"
+               type="jakartaee:partial-responseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "partial-response" element is the root of the
+        partial response information hierarchy, and contains
+        nested elements for all possible elements that can exist
+        in the response.</p>
+        
+        <p>This element must have an "id" attribute whose value
+        is the return from calling getContainerClientId() on the
+        UIViewRoot to which this response pertains.
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+  </xsd:element>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-responseType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "partial-response" element is the root of the
+        partial response information hierarchy, and contains
+        nested elements for all possible elements that can exist
+        in the response.
+        
+        <p>
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="changes"
+                   type="jakartaee:partial-response-changesType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="redirect"
+                   type="jakartaee:partial-response-redirectType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+      <xsd:element name="error"
+                   type="jakartaee:partial-response-errorType"
+                   minOccurs="0"
+                   maxOccurs="1"/>
+    </xsd:choice>
+    <xsd:attribute name="id"
+                   type="xsd:ID"
+                   use="required">
+      <xsd:annotation>
+        <xsd:documentation>
+          <![CDATA[
+          [
+          <p class="changed_added_2_2">This element must have an "id" attribute whose value
+          is the return from calling getContainerClientId() on the
+          UIViewRoot to which this response pertains.<p> 
+          
+          ]]>
+        </xsd:documentation>
+      </xsd:annotation>
+    </xsd:attribute>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-changesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "changes" element contains a collection of child elements,
+        each of which describes a different change to be applied to the
+        view in the user agent.
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="0"
+                maxOccurs="unbounded">
+      <xsd:element name="update"
+                   type="jakartaee:partial-response-updateType"/>
+      <xsd:element name="insert"
+                   type="jakartaee:partial-response-insertType"/>
+      <xsd:element name="delete"
+                   type="jakartaee:partial-response-deleteType"/>
+      <xsd:element name="attributes"
+                   type="jakartaee:partial-response-attributesType"/>
+      <xsd:element name="eval"
+                   type="xsd:string">
+        <xsd:annotation>
+          <xsd:documentation>
+            <![CDATA[
+            [
+            <p>
+            
+            The "eval" element enables this element's
+            contents to be executed as JavaScript.
+            
+            </p>
+            
+            ]]>
+          </xsd:documentation>
+        </xsd:annotation>
+      </xsd:element>
+      <xsd:element name="extension"
+                   type="jakartaee:partial-response-extensionType"/>
+    </xsd:choice>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-updateType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "update" element enables DOM elements matching the "id"
+        attribute to be updated with the contents of this element. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence maxOccurs="unbounded">
+      <xsd:any processContents="skip"
+               namespace="##any"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-insertType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "insert" element enables content to be inserted into the DOM
+        before or after an existing DOM element as specified by the
+        nested "before" or "after" elements.  The elements "before" and
+        "after" are mutually exclusive - one of them must be specified. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:choice minOccurs="1"
+                maxOccurs="1">
+      <xsd:element name="before">
+
+<!-- **************************************************** -->
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any namespace="##any"
+                     processContents="lax"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="id"
+                         type="xsd:string"
+                         use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+      <xsd:element name="after">
+
+<!-- **************************************************** -->
+
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:any namespace="##any"
+                     processContents="lax"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="id"
+                         type="xsd:string"
+                         use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:choice>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-deleteType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "delete" element enables DOM elements matching the "id"
+        attribute to be removed. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="id"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-attributesType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "attributes" element enables attributes of DOM elements matching the "id"
+        attribute to be updated.  If this element is used, then it must contain at
+        least one "attribute" element. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="attribute"
+                   minOccurs="1"
+                   maxOccurs="unbounded">
+
+<!-- **************************************************** -->
+
+        <xsd:complexType>
+          <xsd:attribute name="name"
+                         type="xsd:string"
+                         use="required"/>
+          <xsd:attribute name="value"
+                         type="xsd:string"
+                         use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-redirectType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "redirect" element enables a redirect to the location as specified by the
+        "url" attribute. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:attribute name="url"
+                   type="xsd:string"
+                   use="required"/>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-errorType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        
+        The "error" element contains error information from the server. 
+        
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:element name="error-name"
+                   type="xsd:string"
+                   minOccurs="1"
+                   maxOccurs="1"/>
+      <xsd:element name="error-message"
+                   type="xsd:string"
+                   minOccurs="1"
+                   maxOccurs="1"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+
+<!-- **************************************************** -->
+
+  <xsd:complexType name="partial-response-extensionType">
+    <xsd:annotation>
+      <xsd:documentation>
+        <![CDATA[
+        [
+        <p>
+        Extension element for partial response.  It may contain
+        implementation specific content.
+        </p>
+        
+        ]]>
+      </xsd:documentation>
+    </xsd:annotation>
+    <xsd:sequence>
+      <xsd:any namespace="##any"
+               processContents="lax"
+               minOccurs="0"
+               maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="id"
+                   type="xsd:ID"/>
+  </xsd:complexType>
+
+</xsd:schema>


### PR DESCRIPTION
This also updates XMLResourceResolver to resolve other xsds that are packaged in JBoss Metadata archives but did not have entries in the resolution map. I only did this for ones where the xsd was available under the http://xmlns.jcp.org/xml/ns/javaee/ path. (There were a few that we provide but there was no working URL; those were not added.)

Note that WildFly does not use the JBoss Metadata XMLResourceResolver class.

https://issues.redhat.com/browse/JBMETA-420