### PR TITLE
[JBMETA-429][JBMETA-430] Better document priority when serving files that are contained in web overlays

### DIFF
--- a/web/src/main/resources/schema/jboss-web_14_1.xsd
+++ b/web/src/main/resources/schema/jboss-web_14_1.xsd
@@ -230,6 +230,8 @@
                 web application. The content of the element should be a folder in the
                 filesystem containing the static files that will overlay the webapp's
                 static files, similar to what happens with regular JAR overlays.
+                If a file is found in both the deployment and in the overlay folder,
+                the file in the deployment takes precedence.
             </xsd:documentation>
         </xsd:annotation>
         <xsd:simpleContent>

--- a/web/src/main/resources/schema/jboss-web_14_1.xsd
+++ b/web/src/main/resources/schema/jboss-web_14_1.xsd
@@ -231,7 +231,10 @@
                 filesystem containing the static files that will overlay the webapp's
                 static files, similar to what happens with regular JAR overlays.
                 If a file is found in both the deployment and in the overlay folder,
-                the file in the deployment takes precedence.
+                the file in the deployment takes precedence. If more than one overlay
+                is provided, the order in which the overlay elements are declared
+                determines precedence for files that can be found in multiple overlay
+                folders.
             </xsd:documentation>
         </xsd:annotation>
         <xsd:simpleContent>


### PR DESCRIPTION
Jiras:
https://issues.redhat.com/browse/JBMETA-429 Document that overlays in jboss-web do not override
https://issues.redhat.com/browse/JBMETA-430 Document the priority order for jboss-web.xml overlays