### PR TITLE
[JBMETA-452] At WebMetaDtaParser, add a requireNoContent(reader) afte…

### DIFF
--- a/web/src/main/java/org/jboss/metadata/parser/servlet/WebMetaDataParser.java
+++ b/web/src/main/java/org/jboss/metadata/parser/servlet/WebMetaDataParser.java
@@ -184,6 +184,7 @@ public class WebMetaDataParser extends MetaDataElementParser {
                     //https://www.oracle.com/webfolder/technetwork/jsc/xml/ns/javaee/web-app_4_0.xsd
                     //<xsd:element name="deny-uncovered-http-methods" type="javaee:emptyType">
                     wmd.setDenyUncoveredHttpMethods(Boolean.TRUE);
+                    requireNoContent(reader);
                     break;
                 case DEFAULT_CONTEXT_PATH:
                     wmd.setDefaultContextPath(getElementText(reader, propertyReplacer));

--- a/web/src/test/java/org/jboss/test/metadata/web/WebApp6EverythingUnitTestCase.java
+++ b/web/src/test/java/org/jboss/test/metadata/web/WebApp6EverythingUnitTestCase.java
@@ -72,6 +72,7 @@ public class WebApp6EverythingUnitTestCase extends WebAppUnitTestCase {
         assertServletMappings(webApp);
         assertFilters(webApp);
         assertFilterMappings(webApp);
+        assertDenyUncoveredHttpMethods(webApp);
         assertSecurityConstraints(webApp);
         assertAbsoluteOrdering(webApp);
         assertNotNull("no session config set", webApp.getSessionConfig());
@@ -175,6 +176,10 @@ public class WebApp6EverythingUnitTestCase extends WebAppUnitTestCase {
         assertEquals(2, dispatchers.size());
         assertEquals(DispatcherType.FORWARD, dispatchers.get(0));
         assertEquals(DispatcherType.REQUEST, dispatchers.get(1));
+    }
+
+    protected void assertDenyUncoveredHttpMethods(WebMetaData webApp) {
+        assertNull(webApp.getDenyUncoveredHttpMethods());
     }
 
     // Security Constraints

--- a/web/src/test/java/org/jboss/test/metadata/web/WebApp8EverythingUnitTestCase.java
+++ b/web/src/test/java/org/jboss/test/metadata/web/WebApp8EverythingUnitTestCase.java
@@ -21,6 +21,8 @@
  */
 package org.jboss.test.metadata.web;
 
+import javax.xml.stream.XMLStreamException;
+
 import org.jboss.metadata.merge.javaee.spec.JavaEEVersion;
 import org.jboss.metadata.web.spec.WebMetaData;
 
@@ -35,5 +37,20 @@ public class WebApp8EverythingUnitTestCase extends WebApp6EverythingUnitTestCase
     public void testEverything() throws Exception {
         WebMetaData webApp = unmarshal();
         assertEverything(webApp, Mode.SPEC, JavaEEVersion.V8);
+    }
+
+    public void testInvalidElement() throws Exception {
+        XMLStreamException expectedException = null;
+        try {
+            org.jboss.metadata.web.spec.WebMetaData webApp = unmarshal();
+        } catch (XMLStreamException e) {
+            expectedException = e;
+        }
+        assertNotNull(expectedException);
+    }
+
+    @Override
+    protected void assertDenyUncoveredHttpMethods(org.jboss.metadata.web.spec.WebMetaData webApp) {
+        assertTrue(webApp.getDenyUncoveredHttpMethods());
     }
 }

--- a/web/src/test/resources/org/jboss/test/metadata/web/WebApp8Everything_testInvalidElement.xml
+++ b/web/src/test/resources/org/jboss/test/metadata/web/WebApp8Everything_testInvalidElement.xml
@@ -215,7 +215,9 @@
        </jsp-property-group>
     </jsp-config>
 
-	<deny-uncovered-http-methods/>
+	<!-- invalid -->
+    <deny-uncovered-http-methods>true</deny-uncovered-http-methods>
+
     <security-constraint id="security-constraint0">
        <display-name>security-constraint0-display-name</display-name>
        <web-resource-collection id="web-resource-collection0">


### PR DESCRIPTION
…r finding deny-uncovered-http-methods element.

The goal is to finish parsing that element before reading the next XML element. Also: add tests for deny-uncovered-http-methods parsing.

Signed-off-by: Flavia Rainone <frainone@redhat.com>

Issue: https://issues.redhat.com/browse/JBMETA-452