### PR TITLE
JBMETA-455 org.jboss.metadata.test.ComparePreviousSchemasTestCase fails because of last-major-release property in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>1.1.1.Final</version.org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec>
         <version.org.jboss.ejb3.ext-api>2.3.0.Final</version.org.jboss.ejb3.ext-api>
         <!-- The last major release, used for tests that compare the schemas -->
-        <last-major-release>15.4.0</last-major-release>
+        <last-major-release>16.0.0.Final</last-major-release>
     </properties>
 
     <modules>


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/JBMETA-455