### PR TITLE
Align jboss-parent version from build-config with the same version from the root pom

### DIFF
--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.jboss</groupId>
         <artifactId>jboss-parent</artifactId>
-        <version>39</version>
+        <version>48</version>
     </parent>
 
     <groupId>org.jboss.metadata</groupId>


### PR DESCRIPTION
This alignment is important because in some build systems, we could have errors when deploying the artifacts, because jboss-parent 39 uses maven-deploy-plugin 2.8.2 and jboss-parent 48 uses maven-deploy-plugin 3.1.3.

Real case example that I reproduced on a Red Hat build system:
```
[ERROR] Found multiple major versions of maven-deploy-plugin; this is a malformed project: [org.apache.maven.plugins:maven-deploy-plugin:maven-plugin:3.1.3:runtime, org.apache.maven.plugins:maven-deploy-plugin:maven-plugin:2.8.2:runtime] -> [Help 1]
```